### PR TITLE
Wifi management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,10 @@ notifications:
         on_success: change
         on_failure: always
     email: false
+addons:
+  apt:
+    packages:
+    - autoconf
+    - automake
+    - libdbus-glib-1-dev
+    - libtool

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,7 +47,7 @@ Project's typical development environment requires:
 
 On a Debian-based system, you may use:
 
-    sudo apt-get install python-pip python-virtualenv virtualenvwrapper python-dev libjpeg-dev libxml2-dev libxslt1-dev zlib1g-dev build-essential
+    sudo apt-get install python-pip python-virtualenv virtualenvwrapper python-dev libjpeg-dev libxml2-dev libxslt1-dev zlib1g-dev build-essential libdbus-glib-1-dev
 
 ### Download the souce code
 

--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -207,6 +207,14 @@ STAFF_HOME_CARDS = [
         'description': _('Create, restore, download, upload backups.'),
         'fa': 'life-ring',
     },
+    {
+        'is_staff': True,
+        'category': 'manage',
+        'url': 'server:wifi',
+        'title': _('Wi-Fi'),
+        'description': _('Manage Wi-Fi connections.'),
+        'fa': 'wifi',
+    },
 ]
 
 HOME_CARDS = STAFF_HOME_CARDS + [

--- a/ideascube/serveradmin/templates/serveradmin/index.html
+++ b/ideascube/serveradmin/templates/serveradmin/index.html
@@ -20,6 +20,7 @@
             <li>{% fa 'power-off' 'fa-fw' %} <a href="{% url 'server:power' %}">{% trans "Restart server" %}</a></li>
             <li>{% fa 'life-ring' 'fa-fw' %} <a href="{% url 'server:backup' %}">{% trans "Manage backups" %}</a></li>
             <li>{% fa 'plug' 'fa-fw' %} <a href="{% url 'server:battery' %}">{% trans "Monitor battery" %}</a></li>
+            <li>{% fa 'wifi' 'fa-fw' %} <a href="{% url 'server:wifi' %}">{% trans "Manage Wi-Fi" %}</a></li>
         </ul>
     </div>
 {% endblock third %}

--- a/ideascube/serveradmin/templates/serveradmin/wifi.html
+++ b/ideascube/serveradmin/templates/serveradmin/wifi.html
@@ -6,7 +6,7 @@
 {% for wifi in wifi_list %}
 {% if forloop.first %}<ul class="wifi-list">{% endif %}
     <li>
-        <a class="wifi-network" data-ssid="{{ wifi.ssid }}" data-known="{{ wifi.known }}">
+        <a class="wifi-network" data-ssid="{{ wifi.ssid }}" data-known="{{ wifi.known }}" data-secure="{{ wifi.secure }}">
             {{ wifi.ssid }}
             {% if wifi.connected %}
             <span><i class="fa fa-check"></i></span>

--- a/ideascube/serveradmin/templates/serveradmin/wifi.html
+++ b/ideascube/serveradmin/templates/serveradmin/wifi.html
@@ -24,8 +24,23 @@
 <p>{% trans 'No Wi-Fi available' %}</p>
 {% endfor %}
 
+<div id="passphrase-popup" class="overlay">
+    <div class="popup">
+        <h2>{% trans 'Authentication required' %}</h2>
+        <a class="close" href="#">&times;</a>
+        <div class="content">
+            <p>{% trans 'An encryption key is required to access this network.' %}</p>
+            <form method="POST" action="">
+                {% csrf_token %}
+                <input type="password" id="wifi_key" name="wifi_key" autocomplete="off" />
+                <input type="submit" value="{% trans 'Connect' %}" />
+            </form>
+        </div>
+    </div>
+</div>
+
 <script type="text/javascript">
-    ID.initWifiList('.wifi-network', "{% url 'server:wifi' %}");
+    ID.initWifiList('.wifi-network', '#passphrase-popup', "{% url 'server:wifi' %}");
 </script>
 
 {% endblock twothird %}

--- a/ideascube/serveradmin/templates/serveradmin/wifi.html
+++ b/ideascube/serveradmin/templates/serveradmin/wifi.html
@@ -1,0 +1,27 @@
+{% extends 'serveradmin/index.html' %}
+{% load i18n %}
+
+{% block twothird %}
+<h2>{% trans "Manage Wi-Fi" %}</h2>
+{% for wifi in wifi_list %}
+{% if forloop.first %}<ul class="wifi-list">{% endif %}
+    <li>
+        <a class="wifi-network">
+            {{ wifi.ssid }}
+            {% if wifi.connected %}
+            <span><i class="fa fa-check"></i></span>
+            {% endif %}
+            <span class="right">{{ wifi.strength }}%</span>
+            {% if wifi.secure %}
+            <span class="right"><i class="fa fa-lock"></i></span>
+            {% endif %}
+        </a>
+    </li>
+{% if forloop.last %}
+</ul>
+{% endif %}
+{% empty %}
+<p>{% trans 'No Wi-Fi available' %}</p>
+{% endfor %}
+
+{% endblock twothird %}

--- a/ideascube/serveradmin/templates/serveradmin/wifi.html
+++ b/ideascube/serveradmin/templates/serveradmin/wifi.html
@@ -6,7 +6,7 @@
 {% for wifi in wifi_list %}
 {% if forloop.first %}<ul class="wifi-list">{% endif %}
     <li>
-        <a class="wifi-network">
+        <a class="wifi-network" data-ssid="{{ wifi.ssid }}" data-known="{{ wifi.known }}">
             {{ wifi.ssid }}
             {% if wifi.connected %}
             <span><i class="fa fa-check"></i></span>
@@ -23,5 +23,9 @@
 {% empty %}
 <p>{% trans 'No Wi-Fi available' %}</p>
 {% endfor %}
+
+<script type="text/javascript">
+    ID.initWifiList('.wifi-network', "{% url 'server:wifi' %}");
+</script>
 
 {% endblock twothird %}

--- a/ideascube/serveradmin/templates/serveradmin/wifi.html
+++ b/ideascube/serveradmin/templates/serveradmin/wifi.html
@@ -19,6 +19,7 @@
     </li>
 {% if forloop.last %}
 </ul>
+<p><a href="{% url 'server:wifi_history' %}">{% trans 'History' %}</a></p>
 {% endif %}
 {% empty %}
 <p>{% trans 'No Wi-Fi available' %}</p>

--- a/ideascube/serveradmin/templates/serveradmin/wifi_history.html
+++ b/ideascube/serveradmin/templates/serveradmin/wifi_history.html
@@ -1,0 +1,28 @@
+{% extends 'serveradmin/index.html' %}
+{% load i18n %}
+
+{% block twothird %}
+<h2>{% trans 'Wi-Fi History' %}</h2>
+{% for wifi in wifi_list %}
+{% if forloop.first %}
+<form method="POST" action="{% url 'server:wifi_history' %}" id="wifi_history">
+    {% csrf_token %}
+    <fieldset class="wifi-list" name="ssids">
+{% endif %}
+        <label class="wifi-network" for="{{ wifi.ssid }}">
+            <input type="checkbox" id="{{ wifi.ssid }}" name="{{ wifi.ssid }}" />
+            {{ wifi.ssid }}
+            {% if wifi.connected %}
+            <span><i class="fa fa-check"></i></span>
+            {% endif %}
+        </label>
+{% if forloop.last %}
+    </fieldset>
+    <input type="submit" value="{% trans 'Forget Selected' %}" />
+</form>
+{% endif %}
+{% empty %}
+<p>{% trans 'No known Wi-Fi networks' %}</p>
+{% endfor %}
+
+{% endblock twothird %}

--- a/ideascube/serveradmin/tests/__init__.py
+++ b/ideascube/serveradmin/tests/__init__.py
@@ -1,3 +1,12 @@
+try:
+    from NetworkManager import NM_DEVICE_TYPE_ETHERNET, NM_DEVICE_TYPE_WIFI
+
+except Exception:
+    # Use hard-coded values for the tests, these are constants anyway
+    NM_DEVICE_TYPE_ETHERNET = 1
+    NM_DEVICE_TYPE_WIFI = 2
+
+
 class NMActiveConnection(object):
     def __init__(self, ssid='', is_secure=True):
         self.Connection = NMConnection(True, ssid=ssid, is_secure=is_secure)
@@ -22,3 +31,10 @@ class NMConnection(object):
             settings.update({'802-11-wireless-security': {}})
 
         return settings
+
+
+class NMDevice(object):
+    def __init__(self, is_wifi):
+        self.DeviceType = (
+            NM_DEVICE_TYPE_WIFI if is_wifi else NM_DEVICE_TYPE_ETHERNET)
+        self.Managed = True

--- a/ideascube/serveradmin/tests/__init__.py
+++ b/ideascube/serveradmin/tests/__init__.py
@@ -7,6 +7,14 @@ except Exception:
     NM_DEVICE_TYPE_WIFI = 2
 
 
+class NMAccessPoint(object):
+    def __init__(self, ssid, strength, wpa_flags):
+        self.Ssid = ssid
+        self.Strength = strength
+        self.WpaFlags = wpa_flags
+        self.Frequency = 5000
+
+
 class NMActiveConnection(object):
     def __init__(self, ssid='', is_secure=True):
         self.Connection = NMConnection(True, ssid=ssid, is_secure=is_secure)
@@ -38,3 +46,14 @@ class NMDevice(object):
         self.DeviceType = (
             NM_DEVICE_TYPE_WIFI if is_wifi else NM_DEVICE_TYPE_ETHERNET)
         self.Managed = True
+
+    def SpecificDevice(self):
+        return NMSpecificDevice()
+
+
+class NMSpecificDevice(object):
+    def GetAllAccessPoints(self):
+        return [
+            NMAccessPoint('random open network', 42, 0),
+            NMAccessPoint('', 2, 332),
+            NMAccessPoint('my home network', 99, 332)]

--- a/ideascube/serveradmin/tests/__init__.py
+++ b/ideascube/serveradmin/tests/__init__.py
@@ -1,0 +1,24 @@
+class NMActiveConnection(object):
+    def __init__(self, ssid='', is_secure=True):
+        self.Connection = NMConnection(True, ssid=ssid, is_secure=is_secure)
+
+
+class NMConnection(object):
+    def __init__(self, is_wifi, ssid='', is_secure=True, delete_func=None):
+        self.is_wifi = is_wifi
+        self.is_secure = is_secure
+        self.ssid = ssid
+
+        if delete_func is not None:
+            self.Delete = lambda: delete_func(self)
+
+    def GetSettings(self):
+        if not self.is_wifi:
+            return {}
+
+        settings = {'802-11-wireless': {'ssid': self.ssid}}
+
+        if self.is_secure:
+            settings.update({'802-11-wireless-security': {}})
+
+        return settings

--- a/ideascube/serveradmin/tests/test_wifi.py
+++ b/ideascube/serveradmin/tests/test_wifi.py
@@ -1,7 +1,7 @@
 from mock import MagicMock
 import pytest
 
-from . import NMActiveConnection, NMConnection
+from . import NMActiveConnection, NMConnection, NMDevice
 
 
 def test_list_known_wifi_connections(mocker):
@@ -99,3 +99,33 @@ def test_wifi_cannot_be_enabled(mocker):
 
     with pytest.raises(WifiError):
         enable_wifi()
+
+
+def test_get_wifi_device(mocker):
+    from ideascube.serveradmin.wifi import get_wifi_device, NM_DEVICE_TYPE_WIFI
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.Devices = [NMDevice(False), NMDevice(True)]
+
+    device = get_wifi_device()
+    assert device.DeviceType == NM_DEVICE_TYPE_WIFI
+
+
+def test_get_no_wifi_device(mocker):
+    from ideascube.serveradmin.wifi import get_wifi_device, WifiError
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.Devices = [NMDevice(False)]
+
+    with pytest.raises(WifiError):
+        get_wifi_device()
+
+
+def test_get_multiple_wifi_devices(mocker):
+    from ideascube.serveradmin.wifi import get_wifi_device, WifiError
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.Devices = [NMDevice(True), NMDevice(True)]
+
+    with pytest.raises(WifiError):
+        get_wifi_device()

--- a/ideascube/serveradmin/tests/test_wifi.py
+++ b/ideascube/serveradmin/tests/test_wifi.py
@@ -1,5 +1,67 @@
-from mock import MagicMock, PropertyMock
+from mock import MagicMock
 import pytest
+
+from . import NMActiveConnection, NMConnection
+
+
+def test_list_known_wifi_connections(mocker):
+    from ideascube.serveradmin.wifi import KnownWifiConnection
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.ActiveConnections = []
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: [
+        NMConnection(False),
+        NMConnection(True, ssid='random open network', is_secure=False),
+        NMConnection(True, ssid='my home network'),
+        ]
+
+    connections = KnownWifiConnection.all()
+    assert list(connections.keys()) == [
+        'my home network', 'random open network']
+
+    assert str(connections['my home network']) == (
+        'Known Wi-Fi connection: "my home network"')
+    assert connections['my home network'].connected is False
+    assert connections['my home network'].secure is True
+    assert connections['my home network'].ssid == 'my home network'
+
+    assert str(connections['random open network']) == (
+        'Known Wi-Fi connection: "random open network"')
+    assert connections['random open network'].connected is False
+    assert connections['random open network'].secure is False
+    assert connections['random open network'].ssid == 'random open network'
+
+
+def test_list_known_wifi_connections_with_one_connected(mocker):
+    from ideascube.serveradmin.wifi import KnownWifiConnection
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.ActiveConnections = [NMActiveConnection(ssid='my home network')]
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: [
+        NMConnection(False),
+        NMConnection(True, ssid='random open network', is_secure=False),
+        NMConnection(True, ssid='my home network'),
+        ]
+
+    connections = KnownWifiConnection.all()
+    assert list(connections.keys()) == [
+        'my home network', 'random open network']
+
+    assert str(connections['my home network']) == (
+        'Known Wi-Fi connection: "my home network"')
+    assert connections['my home network'].ssid == 'my home network'
+    assert connections['my home network'].secure is True
+    assert connections['my home network'].connected is True
+
+    assert str(connections['random open network']) == (
+        'Known Wi-Fi connection: "random open network"')
+    assert connections['random open network'].connected is False
+    assert connections['random open network'].secure is False
+    assert connections['random open network'].ssid == 'random open network'
 
 
 def test_enable_wifi(mocker):

--- a/ideascube/serveradmin/tests/test_wifi.py
+++ b/ideascube/serveradmin/tests/test_wifi.py
@@ -4,6 +4,133 @@ import pytest
 from . import NMActiveConnection, NMConnection, NMDevice
 
 
+def test_list_wifi_networks(mocker):
+    from ideascube.serveradmin.wifi import AvailableWifiNetwork
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.Devices = [NMDevice(True)]
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: []
+
+    networks = AvailableWifiNetwork.all()
+    assert list(networks.keys()) == ['my home network', 'random open network']
+
+    assert str(networks['my home network']) == (
+        'Available Wi-Fi network: "my home network"')
+    assert networks['my home network'].connected is False
+    assert networks['my home network'].known is False
+    assert networks['my home network'].secure is True
+    assert networks['my home network'].ssid == 'my home network'
+    assert networks['my home network'].strength == 99
+
+    assert str(networks['random open network']) == (
+        'Available Wi-Fi network: "random open network"')
+    assert networks['random open network'].connected is False
+    assert networks['random open network'].known is False
+    assert networks['random open network'].secure is False
+    assert networks['random open network'].ssid == 'random open network'
+    assert networks['random open network'].strength == 42
+
+
+def test_list_wifi_networks_with_one_known(mocker):
+    from ideascube.serveradmin.wifi import AvailableWifiNetwork
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.Devices = [NMDevice(True)]
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: [
+        NMConnection(False),
+        NMConnection(True, ssid='my home network'),
+        ]
+
+    networks = AvailableWifiNetwork.all()
+    assert list(networks.keys()) == ['my home network', 'random open network']
+
+    assert str(networks['my home network']) == (
+        'Available Wi-Fi network: "my home network"')
+    assert networks['my home network'].connected is False
+    assert networks['my home network'].known is True
+    assert networks['my home network'].secure is True
+    assert networks['my home network'].ssid == 'my home network'
+    assert networks['my home network'].strength == 99
+
+    assert str(networks['random open network']) == (
+        'Available Wi-Fi network: "random open network"')
+    assert networks['random open network'].connected is False
+    assert networks['random open network'].known is False
+    assert networks['random open network'].secure is False
+    assert networks['random open network'].ssid == 'random open network'
+    assert networks['random open network'].strength == 42
+
+
+def test_list_wifi_networks_with_one_connected(mocker):
+    from ideascube.serveradmin.wifi import AvailableWifiNetwork
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.ActiveConnections = [NMActiveConnection(ssid='my home network')]
+    NM.Devices = [NMDevice(True)]
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: [
+        NMConnection(False),
+        NMConnection(True, ssid='my home network'),
+        ]
+
+    networks = AvailableWifiNetwork.all()
+    assert list(networks.keys()) == ['my home network', 'random open network']
+
+    assert str(networks['my home network']) == (
+        'Available Wi-Fi network: "my home network"')
+    assert networks['my home network'].connected is True
+    assert networks['my home network'].known is True
+    assert networks['my home network'].secure is True
+    assert networks['my home network'].ssid == 'my home network'
+    assert networks['my home network'].strength == 99
+
+    assert str(networks['random open network']) == (
+        'Available Wi-Fi network: "random open network"')
+    assert networks['random open network'].connected is False
+    assert networks['random open network'].known is False
+    assert networks['random open network'].secure is False
+    assert networks['random open network'].ssid == 'random open network'
+    assert networks['random open network'].strength == 42
+
+
+def test_list_wifi_networks_with_other_connected(mocker):
+    from ideascube.serveradmin.wifi import AvailableWifiNetwork
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.ActiveConnections = [NMActiveConnection(ssid='my office network')]
+    NM.Devices = [NMDevice(True)]
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: [
+        NMConnection(False),
+        NMConnection(True, ssid='my home network'),
+        ]
+
+    networks = AvailableWifiNetwork.all()
+    assert list(networks.keys()) == ['my home network', 'random open network']
+
+    assert str(networks['my home network']) == (
+        'Available Wi-Fi network: "my home network"')
+    assert networks['my home network'].connected is False
+    assert networks['my home network'].known is True
+    assert networks['my home network'].secure is True
+    assert networks['my home network'].ssid == 'my home network'
+    assert networks['my home network'].strength == 99
+
+    assert str(networks['random open network']) == (
+        'Available Wi-Fi network: "random open network"')
+    assert networks['random open network'].connected is False
+    assert networks['random open network'].known is False
+    assert networks['random open network'].secure is False
+    assert networks['random open network'].ssid == 'random open network'
+    assert networks['random open network'].strength == 42
+
+
 def test_list_known_wifi_connections(mocker):
     from ideascube.serveradmin.wifi import KnownWifiConnection
 

--- a/ideascube/serveradmin/tests/test_wifi.py
+++ b/ideascube/serveradmin/tests/test_wifi.py
@@ -131,6 +131,68 @@ def test_list_wifi_networks_with_other_connected(mocker):
     assert networks['random open network'].strength == 42
 
 
+def test_connect_to_known_open_network(mocker):
+    from ideascube.serveradmin.wifi import AvailableWifiNetwork
+
+    def activate_connection(connection, device, path):
+        NM.ActiveConnections.append(
+            NMActiveConnection(ssid=connection.ssid, is_secure=False))
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.ActivateConnection.side_effect = activate_connection
+    NM.ActiveConnections = []
+    NM.Devices = [NMDevice(True)]
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: [
+        NMConnection(False),
+        NMConnection(True, ssid='random open network', is_secure=False),
+        ]
+
+    networks = AvailableWifiNetwork.all()
+    assert networks['random open network'].connected is False
+    assert networks['random open network'].known is True
+    assert networks['random open network'].secure is False
+    assert networks['random open network'].ssid == 'random open network'
+    assert NM.ActivateConnection.call_count == 0
+    assert NMSettings.AddConnection.call_count == 0
+
+    networks['random open network'].connect()
+    assert NM.ActivateConnection.call_count == 1
+    assert NMSettings.AddConnection.call_count == 0
+    assert networks['random open network'].connected is True
+
+
+def test_connect_to_known_wpa_network(mocker):
+    from ideascube.serveradmin.wifi import AvailableWifiNetwork
+
+    def activate_connection(connection, device, path):
+        NM.ActiveConnections.append(
+            NMActiveConnection(ssid=connection.ssid))
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.ActivateConnection.side_effect = activate_connection
+    NM.ActiveConnections = []
+    NM.Devices = [NMDevice(True)]
+
+    NMSettings = mocker.patch('ideascube.serveradmin.wifi.NMSettings')
+    NMSettings.ListConnections.side_effect = lambda: [
+        NMConnection(False),
+        NMConnection(True, ssid='my home network'),
+        ]
+
+    networks = AvailableWifiNetwork.all()
+    assert networks['my home network'].connected is False
+    assert networks['my home network'].known is True
+    assert networks['my home network'].secure is True
+    assert networks['my home network'].ssid == 'my home network'
+    assert NM.ActivateConnection.call_count == 0
+
+    networks['my home network'].connect()
+    assert NM.ActivateConnection.call_count == 1
+    assert networks['my home network'].connected is True
+
+
 def test_list_known_wifi_connections(mocker):
     from ideascube.serveradmin.wifi import KnownWifiConnection
 

--- a/ideascube/serveradmin/tests/test_wifi.py
+++ b/ideascube/serveradmin/tests/test_wifi.py
@@ -1,0 +1,39 @@
+from mock import MagicMock, PropertyMock
+import pytest
+
+
+def test_enable_wifi(mocker):
+    from ideascube.serveradmin.wifi import enable_wifi
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.WirelessEnabled = False
+    NM.WirelessHardwareEnabled = True
+
+    enable_wifi()
+    assert NM.WirelessEnabled is True
+
+
+def test_wifi_hardware_disabled(mocker):
+    from ideascube.serveradmin.wifi import enable_wifi, WifiError
+
+    NM = mocker.patch('ideascube.serveradmin.wifi.NetworkManager')
+    NM.WirelessEnabled = False
+    NM.WirelessHardwareEnabled = False
+
+    with pytest.raises(WifiError):
+        enable_wifi()
+
+    assert NM.WirelessEnabled is False
+
+
+def test_wifi_cannot_be_enabled(mocker):
+    from ideascube.serveradmin.wifi import enable_wifi, WifiError
+
+    class MockedNM(MagicMock):
+        def __getattr__(self, name):
+            raise AttributeError()
+
+    mocker.patch('ideascube.serveradmin.wifi.NetworkManager', new=MockedNM())
+
+    with pytest.raises(WifiError):
+        enable_wifi()

--- a/ideascube/serveradmin/urls.py
+++ b/ideascube/serveradmin/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     url(r'^services/$', views.services, name='services'),
     url(r'^backup/$', views.backup, name='backup'),
     url(r'^battery/$', views.battery, name='battery'),
+    url(r'^wifi/$', views.wifi, name='wifi'),
 ]

--- a/ideascube/serveradmin/urls.py
+++ b/ideascube/serveradmin/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     url(r'^services/$', views.services, name='services'),
     url(r'^backup/$', views.backup, name='backup'),
     url(r'^battery/$', views.battery, name='battery'),
-    url(r'^wifi/$', views.wifi, name='wifi'),
+    url(r'^wifi/(?P<ssid>.+)?$', views.wifi, name='wifi'),
 ]

--- a/ideascube/serveradmin/urls.py
+++ b/ideascube/serveradmin/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     url(r'^backup/$', views.backup, name='backup'),
     url(r'^battery/$', views.battery, name='battery'),
     url(r'^wifi/(?P<ssid>.+)?$', views.wifi, name='wifi'),
+    url(r'^wifi_history/$', views.wifi_history, name='wifi_history'),
 ]

--- a/ideascube/serveradmin/views.py
+++ b/ideascube/serveradmin/views.py
@@ -115,7 +115,7 @@ def battery(request):
 
 
 @staff_member_required
-def wifi(request):
+def wifi(request, ssid=''):
     try:
         enable_wifi()
         wifi_list = AvailableWifiNetwork.all()
@@ -124,6 +124,19 @@ def wifi(request):
         messages.error(request, e)
         return render(request, 'serveradmin/wifi.html')
 
+    if ssid:
+        try:
+            network = wifi_list[ssid]
+            network.connect()
+            messages.success(
+                request, _('Connected to {ssid}').format(ssid=ssid))
+
+        except KeyError:
+            messages.error(
+                request, _('No such network: {ssid}').format(ssid=ssid))
+
+        except WifiError as e:
+            messages.error(request, e)
 
     return render(
         request, 'serveradmin/wifi.html', {'wifi_list': wifi_list.values()})

--- a/ideascube/serveradmin/views.py
+++ b/ideascube/serveradmin/views.py
@@ -127,7 +127,8 @@ def wifi(request, ssid=''):
     if ssid:
         try:
             network = wifi_list[ssid]
-            network.connect()
+            wifi_key = request.POST.get('wifi_key', '')
+            network.connect(wifi_key=wifi_key)
             messages.success(
                 request, _('Connected to {ssid}').format(ssid=ssid))
 

--- a/ideascube/serveradmin/views.py
+++ b/ideascube/serveradmin/views.py
@@ -11,6 +11,7 @@ from ideascube.decorators import staff_member_required
 
 from .backup import Backup
 from .utils import call_service
+from .wifi import AvailableWifiNetwork, enable_wifi, WifiError
 
 
 @staff_member_required
@@ -111,3 +112,18 @@ def backup(request):
 def battery(request):
     return render(request, 'serveradmin/battery.html',
                   {'batteries': batinfo.batteries()})
+
+
+@staff_member_required
+def wifi(request):
+    try:
+        enable_wifi()
+        wifi_list = AvailableWifiNetwork.all()
+
+    except WifiError as e:
+        messages.error(request, e)
+        return render(request, 'serveradmin/wifi.html')
+
+
+    return render(
+        request, 'serveradmin/wifi.html', {'wifi_list': wifi_list.values()})

--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -13,6 +13,7 @@ try:
     from NetworkManager import (
         NetworkManager,
         Settings as NMSettings,
+        NM_DEVICE_TYPE_WIFI,
         )
 
 except Exception as e:
@@ -22,6 +23,10 @@ except Exception as e:
     # easily if they didn't exist here.
     NetworkManager = None
     NMSettings = None
+
+    # Hardcode this one, it is a constant anyway in the NetworkManager module,
+    # and hardcoding it allows the tests to run no matter what.
+    NM_DEVICE_TYPE_WIFI = 2
 
 
 class KnownWifiConnection(object):
@@ -79,3 +84,20 @@ def enable_wifi():
     except:
         # This will fail if NetworkManager is None, i.e we couldn't import it
         raise WifiError(_("Wi-Fi is disabled"))
+
+
+def get_wifi_device():
+    devices = []
+
+    for device in NetworkManager.Devices:
+        if device.Managed and device.DeviceType == NM_DEVICE_TYPE_WIFI:
+            devices.append(device)
+
+    if not devices:
+        raise WifiError(_("No Wi-Fi device was found"))
+
+    if len(devices) > 1:
+        raise WifiError(
+            _("Found more than one Wi-Fi device, this is not supported"))
+
+    return devices[0]

--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -64,6 +64,14 @@ class AvailableWifiNetwork(object):
     def __str__(self):
         return 'Available Wi-Fi network: "%s"' % (self.ssid)
 
+    def connect(self):
+        if self._connection is not None:
+            NetworkManager.ActivateConnection(
+                self._connection._connection, self._device, "/")
+
+        else:
+            raise WifiError("Can't connect to a new network yet")
+
     @property
     def connected(self):
         return self._connection and self._connection.connected or False

--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -1,0 +1,38 @@
+from django.utils.translation import ugettext as _
+
+try:
+    # The NetworkManager module tries to connect to the NetworkManager daemon
+    # right when we import it.
+    #
+    # Therefore, if there is no NetworkManager daemon running, or if it isn't
+    # reachable for some reason (like in our CI servers), the imports will
+    # fail.
+    from NetworkManager import (
+        NetworkManager,
+        )
+
+except Exception as e:
+    # Set these to None so they exist, the code will handle exceptions.
+    #
+    # It also helps with unit tests, which wouldn't be able to mock them as
+    # easily if they didn't exist here.
+    NetworkManager = None
+
+
+class WifiError(Exception):
+    pass
+
+
+def enable_wifi():
+    try:
+        if not NetworkManager.WirelessHardwareEnabled:
+            raise WifiError(_("Wi-Fi hardware is disabled"))
+
+        NetworkManager.WirelessEnabled = True
+
+    except WifiError:
+        raise
+
+    except:
+        # This will fail if NetworkManager is None, i.e we couldn't import it
+        raise WifiError(_("Wi-Fi is disabled"))

--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -148,6 +148,9 @@ class KnownWifiConnection(object):
     def __str__(self):
         return 'Known Wi-Fi connection: "%s"' % (self.ssid)
 
+    def forget(self):
+        self._connection.Delete()
+
     @property
     def connected(self):
         for active_connection in NetworkManager.ActiveConnections:

--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -65,7 +65,7 @@ class AvailableWifiNetwork(object):
     def __str__(self):
         return 'Available Wi-Fi network: "%s"' % (self.ssid)
 
-    def _new_connection(self):
+    def _new_connection(self, wifi_key=None):
         settings = {
             'connection': {
                 'autoconnect': True,
@@ -85,15 +85,27 @@ class AvailableWifiNetwork(object):
                 }
             }
 
+        if self.secure:
+            if not wifi_key:
+                raise WifiError(
+                    _("A key is required to connect to this network"))
+
+            settings.update({
+                '802-11-wireless-security': {
+                    'auth-alg': 'open',
+                    'key-mgmt': 'wpa-psk',
+                    'psk': wifi_key,
+                    }})
+
         return KnownWifiConnection(NMSettings.AddConnection(settings))
 
-    def connect(self):
+    def connect(self, wifi_key=None):
         if self._connection is not None:
             NetworkManager.ActivateConnection(
                 self._connection._connection, self._device, "/")
 
         else:
-            self._connection = self._new_connection()
+            self._connection = self._new_connection(wifi_key=wifi_key)
 
     @property
     def connected(self):

--- a/ideascube/static/ideascube/js/ideascube.js
+++ b/ideascube/static/ideascube/js/ideascube.js
@@ -267,7 +267,7 @@ ID.confirmClick = function (selector) {
 };
 
 
-ID.initWifiList = function (item_selector, urlroot) {
+ID.initWifiList = function (item_selector, popup_selector, urlroot) {
     var elements = document.querySelectorAll(item_selector);
 
     for (var i = 0; i < elements.length; ++i) {
@@ -278,6 +278,14 @@ ID.initWifiList = function (item_selector, urlroot) {
         if (known || !secure) {
             var ssid = element.getAttribute('data-ssid');
             element.setAttribute('href', urlroot + ssid);
+        } else {
+            element.setAttribute('href', popup_selector);
+
+            element.addEventListener('click', function (evt) {
+                var ssid = this.getAttribute('data-ssid');
+                var form = document.querySelector(popup_selector + ' form');
+                form.setAttribute('action', urlroot + ssid);
+            }.bind(element), true);
         }
     }
 };

--- a/ideascube/static/ideascube/js/ideascube.js
+++ b/ideascube/static/ideascube/js/ideascube.js
@@ -273,8 +273,9 @@ ID.initWifiList = function (item_selector, urlroot) {
     for (var i = 0; i < elements.length; ++i) {
         var element = elements[i];
         var known = element.getAttribute('data-known') === 'True';
+        var secure = element.getAttribute('data-secure') === 'True';
 
-        if (known) {
+        if (known || !secure) {
             var ssid = element.getAttribute('data-ssid');
             element.setAttribute('href', urlroot + ssid);
         }

--- a/ideascube/static/ideascube/js/ideascube.js
+++ b/ideascube/static/ideascube/js/ideascube.js
@@ -265,3 +265,18 @@ ID.confirmClick = function (selector) {
     };
     el.addEventListener('click', ask, false);
 };
+
+
+ID.initWifiList = function (item_selector, urlroot) {
+    var elements = document.querySelectorAll(item_selector);
+
+    for (var i = 0; i < elements.length; ++i) {
+        var element = elements[i];
+        var known = element.getAttribute('data-known') === 'True';
+
+        if (known) {
+            var ssid = element.getAttribute('data-ssid');
+            element.setAttribute('href', urlroot + ssid);
+        }
+    }
+};

--- a/ideascube/static/ideascube/main.css
+++ b/ideascube/static/ideascube/main.css
@@ -670,6 +670,48 @@ span.error {
     float: right;
 }
 
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  transition: opacity 500ms;
+  visibility: hidden;
+  opacity: 0;
+}
+.overlay:target {
+  visibility: visible;
+  opacity: 1;
+}
+.popup {
+  margin: 250px auto;
+  padding: 20px;
+  background: #fff;
+  border-radius: 5px;
+  width: 35%;
+  position: relative;
+  transition: all 5s ease-in-out;
+}
+.popup h2 {
+  margin-top: 0;
+  color: #333;
+}
+.popup .close {
+  position: absolute;
+  top: 20px;
+  right: 30px;
+  transition: all 200ms;
+  font-size: 30px;
+  font-weight: bold;
+  text-decoration: none;
+  color: #333;
+}
+.popup .close:hover {
+  color: #06D85F;
+}
+
 
 /* ************************************************* */
 /* ******************** HOME *********************** */

--- a/ideascube/static/ideascube/main.css
+++ b/ideascube/static/ideascube/main.css
@@ -666,6 +666,10 @@ span.error {
     content: ' ♬';
 }
 
+.right {
+    float: right;
+}
+
 
 /* ************************************************* */
 /* ******************** HOME *********************** */
@@ -735,6 +739,25 @@ img.cover {
 .services .status-error h3 span,
 .services .status-off h3 span {
     color: #C0392B;
+}
+
+.wifi-list {
+    border: 1px solid #ddd;
+    padding: 0;
+    margin: 0;
+}
+.wifi-network {
+    text-decoration: none;
+    display: block;
+    padding: 1em;
+    border-bottom: 1px dotted #ddd;
+}
+.wifi-network:hover {
+    background-color: #f1f1f1;
+    cursor: pointer;
+}
+.wifi-network span {
+    margin: auto 1em;
 }
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ pyquery==1.2.9
 pytest==2.8.2
 pytest-cov==2.2.0
 pytest-django==2.9.1
+pytest-mock==0.8.1
 transifex-client==0.10
 WebTest==2.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,19 @@ django-select-multiple-field==0.4.1
 django-taggit==0.17.3
 Pillow==3.0.0
 pymarc==3.0.4
+python-networkmanager==1.0.1
 Unidecode==0.4.18
+
+# Upstream dbus-python is not pip-installable:
+#     https://bugs.freedesktop.org/show_bug.cgi?id=55439
+#
+# So there is a fork on Github that **only** makes it pipi-installable:
+#     https://github.com/posborne/dbus-python
+#
+# But that's for the master branch... which we can't use, because our Travis
+# CI base is Ubuntu 12.04, which has DBus 1.4.18, and dbus-python master
+# requires DBus >= 1.6.
+#
+# So we forked the forked, backporting the pip-related patches to the 1.1.1
+# branch, and we use that here.
+git+https://github.com/bochecha/dbus-python.git@pipified-1.1.1#egg=dbus


### PR DESCRIPTION
Here is wifi management for the admin interface.

It is still a work in progress, so don't merge it just yet.

However, it does enough that it's worth sharing, if only to enable early review.

Also, note that I'll be rebasing this branch, so if you fetch it locally be prepared to have to force things a bit. :wink: 

What's done and missing:

* [x] List all wifi networks
* [x] Connect to a wifi network (without sudo)
 * [x] Open network
 * [x] WPA-protected network
 * [ ] Other network security types?
* [x] Forget a network
* [ ] Connect to hidden network?

Do we want to support other types of network security? WEP just shouldn't be used any more now, and I'm not sure the various "enterprise" types are very useful for our target. :smiley: 

Do we want to support connecting to a hidden network? (that is, one which does not advertise its SSID)

Is there anything else the admin app should be able to do with Wifi networks?

Screenshots of how it looks like are at: https://bochecha.fedorapeople.org/ideascube/