### PR TITLE
tests: Don't run coverage by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 install:
 - make develop
 - pip install python-coveralls
-script: make test
+script: make testcov
 after_success:
 - coveralls
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 test:
 	py.test
+testcov:
+	py.test --cov=ideascube/ --cov-report=term-missing
 develop:
 	pip install -r requirements-dev.txt
 doc:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=ideascube.settings
 norecursedirs = debian
-addopts = --cov=ideascube/ --cov-report=term-missing


### PR DESCRIPTION
The coverage report takes a lot of space, which can distract from the actual test results.

This commit makes it so that running "py.test" or "make test" doesn't check for coverage any more at all.

A new "make testcov" target is introduced, which both runs the tests and reports coverage.