### PR TITLE
Quick start using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:wheezy
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y python-pip python-virtualenv virtualenvwrapper python-dev libjpeg-dev libxml2-dev libxslt1-dev zlib1g-dev build-essential gettext
+
+ADD . /usr/src/app
+
+WORKDIR /usr/src/app
+
+RUN pip install --upgrade pip
+RUN make develop
+RUN python manage.py migrate && \
+    make dummydata
+RUN make compile_translations
+
+EXPOSE 8000
+
+ENTRYPOINT ["python"]
+CMD ["manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM debian:wheezy
+FROM debian:jessie
 
+RUN echo 'deb-src http://ftp.debian.org/debian/ jessie main' >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y python-pip python-virtualenv virtualenvwrapper python-dev libjpeg-dev libxml2-dev libxslt1-dev zlib1g-dev build-essential gettext
+RUN apt-get install -y python3-pip python3-dev libjpeg-dev libxml2-dev libxslt1-dev zlib1g-dev build-essential autoconf automake libtool libdbus-glib-1-dev git
+RUN apt-get build-dep -y python3-dbus
 
 ADD . /usr/src/app
 
 WORKDIR /usr/src/app
 
-RUN pip install --upgrade pip
 RUN make develop
-RUN python manage.py migrate && \
+RUN python3 manage.py migrate && \
     make dummydata
-RUN make compile_translations
 
 EXPOSE 8000
 
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@ More details about the server in the [overview](https://github.com/ideascube/ide
 ## Try it
 You can try it using docker:
 
+On a Linux box:
+
 - Install docker (www.docker.com)
-- Launch `docker run -p 8000:8000 -d ygravrand/ideascube`
+- launch `docker run -p 8000:8000 -d ideascube/ideascube`
 - Go to `http://localhost:8000`
+
+On Windows or MacOS:
+
+- Install Kitematic (www.kitematic.com)
+- Search for `ìdeascube/ideascube` image and click on `Create`
+- Click on the icon next to `Web preview` to open your web browser
 
 ## How can I give a hand?
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ On a Linux box:
 
 On Windows or MacOS:
 
-- Install Kitematic (www.kitematic.com)
-- Search for `ìdeascube/ideascube` image and click on `Create`
+- Install Docker Toolbox (https://www.docker.com/products/docker-toolbox)
+- Launch Kitematic which should have been installed
+- Search for ``ideascube`` image and click on `Create`
 - Click on the icon next to `Web preview` to open your web browser
 
 ## How can I give a hand?

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ More details about the server in the [overview](https://github.com/ideascube/ide
 
 [ideascube is free software, published under the terms of MIT license](https://github.com/ideascube/ideascube/LICENSE.md).
 
+## Try it
+You can try it using docker:
+
+- Install docker (www.docker.com)
+- Launch `docker run -p 8000:8000 -d ygravrand/ideascube`
+- Go to `http://localhost:8000`
+
 ## How can I give a hand?
 
 Welcome! There are many ways you can help. See details in


### PR DESCRIPTION
Docker allows one to try software easily.
The proposed docker image is based on the target Ideasbox OS.
It has been uploaded on ygravrand/ideascube for now, but can be rebuilt freely.
"Wikipedia" and "Khan academy" links don't work as they need other systems to be installed; however I feel this could be done in the docker image too.
