### PR TITLE
csv: Do not export private user information

### DIFF
--- a/ideascube/models.py
+++ b/ideascube/models.py
@@ -62,6 +62,11 @@ class User(SearchMixin, TimeStampedModel, AbstractBaseUser):
         ('r', _('Read')),
     )
 
+    PRIVATE_DATA = (
+        'short_name',
+        'full_name',
+    )
+
     serial = models.CharField(max_length=40, unique=True)
     short_name = models.CharField(_('usual name'), max_length=30, blank=True)
     full_name = models.CharField(_('full name'), max_length=100, blank=True)

--- a/ideascube/tests/test_views.py
+++ b/ideascube/tests/test_views.py
@@ -329,27 +329,22 @@ def test_export_users_should_return_csv_with_users(staffapp, settings):
     user1 = UserFactory(short_name="user1", full_name="I'm user1")
     user2 = UserFactory(short_name="user2", full_name=u"I'm user2 with é")
     resp = staffapp.get(reverse('user_export'), status=200)
-    resp.mustcontain('created at')
-    resp.mustcontain('full name')
-    resp.mustcontain('serial')
-    resp.mustcontain('usual name')
-    resp.mustcontain(user1.short_name)
-    resp.mustcontain(user1.full_name)
-    resp.mustcontain(user2.short_name)
-    resp.mustcontain(user2.full_name)
+    resp.mustcontain(
+        'serial', user1.serial, user2.serial, no=[
+            'usual name', user1.short_name, user2.short_name,
+            'full_name', user1.full_name, user2.full_name,
+            ])
 
 
 def test_export_users_should_be_ok_in_arabic(staffapp, settings):
     translation.activate('ar')
-    user1 = UserFactory(short_name="user1", full_name=u"جبران خليل جبران")
-    user2 = UserFactory(short_name="user2", full_name=u"النبي (كتاب)")
+    user1 = UserFactory(serial=u"جبران خليل جبران")
+    user2 = UserFactory(serial=u"النبي (كتاب)")
     resp = staffapp.get(reverse('user_export'), status=200)
-    field, _, _, _ = user_model._meta.get_field_by_name('full_name')
+    field, _, _, _ = user_model._meta.get_field_by_name('serial')
     resp.mustcontain(unicode(field.verbose_name))
-    resp.mustcontain(user1.short_name)
-    resp.mustcontain(user1.full_name)
-    resp.mustcontain(user2.short_name)
-    resp.mustcontain(user2.full_name)
+    resp.mustcontain(user1.serial)
+    resp.mustcontain(user2.serial)
     translation.deactivate()
 
 

--- a/ideascube/views.py
+++ b/ideascube/views.py
@@ -175,7 +175,8 @@ class UserExport(CSVExportMixin, View):
         return user_model.objects.all()
 
     def get_headers(self):
-        self.fields = user_model.get_data_fields()
+        fields = user_model.get_data_fields()
+        self.fields = [f for f in fields if f.name not in user_model.PRIVATE_DATA]
         return [unicode(f.verbose_name).encode('utf-8') for f in self.fields]
 
     def get_row(self, user):


### PR DESCRIPTION
We don't need to know about a user's real name, the (hopefully anonymous) serial is enough for our data collection purposes.

I'm only hiding the fields @barbayellow explicitly mentioned to me. However, there seems to be other potentially private informations in other fields, that we probably shouldn't have in CSV exports. Things like the family or marital status, or even the gender.

In any case, those would just need to be added to the new `User.PRIVATE_DATA` field, and then they would not be exported to CSVs any more.