### PR TITLE
wifi: Don't crash if dbus can't be imported

### DIFF
--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -3,11 +3,11 @@ from itertools import groupby
 from operator import attrgetter
 from uuid import uuid4
 
-from dbus import DBusException
-
 from django.utils.translation import ugettext as _
 
 try:
+    from dbus import DBusException
+
     # The NetworkManager module tries to connect to the NetworkManager daemon
     # right when we import it.
     #


### PR DESCRIPTION
On some openrating systems (e.g Mac OS X) DBus isn't available.

Therefore, the dbus-python module can't be built and installed.

With this commit, all that happens is that the Wi-Fi management page is not available, dsplaying the "Wi-Fi is disabled" message, instead of spewing 500 errors.

Fix #218