### PR TITLE
Debian packaging fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,14 @@ Source: ideascube
 Section: python
 Priority: extra
 Maintainer: Yohan Boniface <hi@yohanboniface.me>
-Build-Depends: debhelper (>= 9), python, dh-virtualenv (>= 0.6)
+Build-Depends: debhelper (>= 9), dh-virtualenv (>= 0.6),
+  python, python-dev, python-setuptools,
+# For Pillow
+  libjpeg-dev, zlib1g-dev,
+# For lxml
+  libxml2-dev, libxslt1-dev,
+# For dbus-python
+  git, libdbus-glib-1-dev, autoconf, automake, libtool
 Standards-Version: 3.9.5
 
 Package: ideascube

--- a/debian/control
+++ b/debian/control
@@ -15,5 +15,5 @@ Standards-Version: 3.9.5
 Package: ideascube
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1), python2.7-minimal | python2.6-minimal, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}
+Depends: nginx, uwsgi, uwsgi-plugin-python, ${python:Depends}, ${misc:Depends}
 Description: Ideascube media server

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv
+	dh $@ --with python-virtualenv --buildsystem pybuild
 
 override_dh_virtualenv:
 	dh_virtualenv --preinstall="pip>7" --preinstall wheel


### PR DESCRIPTION
With this, we can build a Debian package for ideascube with the [sbuild](https://wiki.debian.org/sbuild) command, and with correct dependencies.

`sbuild` allows building the package in a chroot, populated only with packages from the Jessie repos (which entirely avoids issues like the one @fheslouin regularly has with libjpeg), in a completely unattended and (almost) reproducible way.

This in turn will allow us to build packages in a [Buildbot](https://buildbot.net/). And in fact, I have a local Buildbot which just successfully built a Debian package for Ideascube, which should make @barbayellow happy. :smile: 