### PR TITLE
server admin: ensure backup root exists (fix #244)

### DIFF
--- a/ideascube/serveradmin/backup.py
+++ b/ideascube/serveradmin/backup.py
@@ -38,6 +38,8 @@ class Backup(object):
             raise ValueError(msg.format(extensions=self.SUPPORTED_EXTENSIONS))
         self.name = name
         self.parse_name()
+        if not os.path.exists(Backup.ROOT):
+            os.makedirs(Backup.ROOT)
 
     def __str__(self):
         return self.name

--- a/ideascube/serveradmin/tests/test_views.py
+++ b/ideascube/serveradmin/tests/test_views.py
@@ -1,5 +1,6 @@
 from io import StringIO
 import os
+import shutil
 import zipfile
 
 import pytest
@@ -241,6 +242,8 @@ def test_backup_button_should_save_a_new_backup(staffapp, monkeypatch,
         os.makedirs(BACKUPED_ROOT)
     except OSError:
         pass
+    if os.path.exists(BACKUPS_ROOT):
+        shutil.rmtree(BACKUPS_ROOT)
     filename = 'edoardo-0.0.0-201501231405.zip'
     filepath = os.path.join(BACKUPS_ROOT, filename)
     try:
@@ -303,6 +306,8 @@ def test_upload_button_create_new_backup_with_uploaded_file(staffapp,
                                                             monkeypatch):
     monkeypatch.setattr('ideascube.serveradmin.backup.Backup.ROOT',
                         BACKUPS_ROOT)
+    if os.path.exists(BACKUPS_ROOT):
+        shutil.rmtree(BACKUPS_ROOT)
     backup_name = 'musasa-0.1.0-201501241620.zip'
     backup_path = os.path.join(BACKUPS_ROOT, backup_name)
     assert not os.path.exists(backup_path)


### PR DESCRIPTION
When a Backup() object is instantiated, ensure the backup root directory
exists. It is implicitly created by the create() method, but not by
other methods such as load().

Signed-off-by: Loic Dachary <loic@dachary.org>