### PR TITLE
Move to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.4"
 sudo: false
 install:
 - make develop

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: extra
 Maintainer: Yohan Boniface <hi@yohanboniface.me>
 Build-Depends: debhelper (>= 9), dh-virtualenv (>= 0.6),
-  python, python-dev, python-setuptools,
+  python3, python3-dev, python3-setuptools,
 # For Pillow
   libjpeg-dev, zlib1g-dev,
 # For lxml
@@ -14,6 +14,6 @@ Standards-Version: 3.9.5
 
 Package: ideascube
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.1), python2.7-minimal | python2.6-minimal, ${misc:Pre-Depends}
-Depends: nginx, uwsgi, uwsgi-plugin-python, ${python:Depends}, ${misc:Depends}
+Pre-Depends: dpkg (>= 1.16.1), python3-minimal, ${misc:Pre-Depends}
+Depends: nginx, uwsgi, uwsgi-plugin-python3, ${python:Depends}, ${misc:Depends}
 Description: Ideascube media server

--- a/debian/rules
+++ b/debian/rules
@@ -4,4 +4,4 @@
 	dh $@ --with python-virtualenv --buildsystem pybuild
 
 override_dh_virtualenv:
-	dh_virtualenv --preinstall="pip>7" --preinstall wheel
+	dh_virtualenv --preinstall="pip>7" --preinstall wheel --python /usr/bin/python3.4

--- a/ideascube/blog/models.py
+++ b/ideascube/blog/models.py
@@ -63,18 +63,18 @@ class Content(SearchMixin, TimeStampedModel, models.Model):
     objects = ContentQuerySet.as_manager()
     tags = TaggableManager(blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
     def get_absolute_url(self):
         return reverse('blog:content_detail', kwargs={'pk': self.pk})
 
     def get_author_display(self):
-        return self.author_text or unicode(self.author)
+        return self.author_text or str(self.author)
 
     @property
     def index_strings(self):
-        return (self.title, self.text, self.author_text, unicode(self.author),
+        return (self.title, self.text, self.author_text, str(self.author),
                 u' '.join(self.tags.names()))
 
     @property

--- a/ideascube/blog/models.py
+++ b/ideascube/blog/models.py
@@ -7,7 +7,7 @@ from taggit.managers import TaggableManager
 from taggit.models import TagBase
 from unidecode import unidecode
 
-from ideascube.models import TimeStampedModel
+from ideascube.models import SortedTaggableManager, TimeStampedModel
 from ideascube.search.models import SearchableQuerySet, SearchMixin
 
 
@@ -61,7 +61,7 @@ class Content(SearchMixin, TimeStampedModel, models.Model):
                             default=settings.LANGUAGE_CODE)
 
     objects = ContentQuerySet.as_manager()
-    tags = TaggableManager(blank=True)
+    tags = TaggableManager(blank=True, manager=SortedTaggableManager)
 
     def __str__(self):
         return self.title

--- a/ideascube/blog/tests/test_factories.py
+++ b/ideascube/blog/tests/test_factories.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.django_db
 def test_it_should_create_a_default_content_from_factory():
     content = ContentFactory()
     assert content.pk is not None
-    assert unicode(content)
+    assert str(content)
 
 
 def test_it_should_override_fields_passed_to_factory():

--- a/ideascube/blog/tests/test_models.py
+++ b/ideascube/blog/tests/test_models.py
@@ -14,4 +14,4 @@ def test_get_author_display_should_return_author_text(published):
 def test_get_author_display_should_return_author_if_no_author_text(user):
     content = ContentFactory(author=user)
     content.author_text = ''
-    assert content.get_author_display() == unicode(user)
+    assert content.get_author_display() == str(user)

--- a/ideascube/blog/tests/test_views.py
+++ b/ideascube/blog/tests/test_views.py
@@ -19,10 +19,10 @@ def test_anonymous_should_access_index_page(app):
 def test_only_published_should_be_in_index(app, published, draft, deleted,
                                            published_in_the_future):
     response = app.get(reverse('blog:index'))
-    assert published.title in response.content
-    assert draft.title not in response.content
-    assert deleted.title not in response.content
-    assert published_in_the_future.title not in response.content
+    assert published.title in response.content.decode()
+    assert draft.title not in response.content.decode()
+    assert deleted.title not in response.content.decode()
+    assert published_in_the_future.title not in response.content.decode()
 
 
 def test_index_page_is_paginated(app, monkeypatch):
@@ -193,8 +193,8 @@ def test_by_tag_page_should_be_filtered_by_tag(app):
     plane = ContentFactory(status=Content.PUBLISHED, tags=['plane'])
     boat = ContentFactory(status=Content.PUBLISHED, tags=['boat'])
     response = app.get(reverse('blog:by_tag', kwargs={'tag': 'plane'}))
-    assert plane.title in response.content
-    assert boat.title not in response.content
+    assert plane.title in response.content.decode()
+    assert boat.title not in response.content.decode()
 
 
 def test_by_tag_page_is_paginated(app, monkeypatch):
@@ -225,7 +225,7 @@ def test_can_create_content_with_tags(staffapp):
     form.submit().follow()
     content = Content.objects.last()
     assert content.tags.count() == 2
-    assert content.tags.first().name == 'tag1'
+    assert 'tag1' in [t.name for t in content.tags.all()]
 
 
 def test_can_update_content_tags(staffapp, published):
@@ -236,4 +236,4 @@ def test_can_update_content_tags(staffapp, published):
     form.submit().follow()
     content = Content.objects.get(pk=published.pk)
     assert content.tags.count() == 2
-    assert content.tags.first().name == 'tag1'
+    assert 'tag1' in [t.name for t in content.tags.all()]

--- a/ideascube/blog/tests/test_views.py
+++ b/ideascube/blog/tests/test_views.py
@@ -225,7 +225,7 @@ def test_can_create_content_with_tags(staffapp):
     form.submit().follow()
     content = Content.objects.last()
     assert content.tags.count() == 2
-    assert 'tag1' in [t.name for t in content.tags.all()]
+    assert content.tags.first().name == 'tag1'
 
 
 def test_can_update_content_tags(staffapp, published):
@@ -236,4 +236,4 @@ def test_can_update_content_tags(staffapp, published):
     form.submit().follow()
     content = Content.objects.get(pk=published.pk)
     assert content.tags.count() == 2
-    assert 'tag1' in [t.name for t in content.tags.all()]
+    assert content.tags.first().name == 'tag1'

--- a/ideascube/fields.py
+++ b/ideascube/fields.py
@@ -15,6 +15,6 @@ class CommaSeparatedCharField(SelectMultipleField):
         def _get_FIELD_display(instance):
             choices = dict(self.choices)
             values = getattr(instance, self.attname)
-            return ", ".join(unicode(choices.get(c, c)) for c in values if c)
+            return ", ".join(str(choices.get(c, c)) for c in values if c)
 
         setattr(cls, 'get_%s_display' % self.name, _get_FIELD_display)

--- a/ideascube/forms.py
+++ b/ideascube/forms.py
@@ -7,7 +7,7 @@ class UserForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(UserForm, self).__init__(*args, **kwargs)
-        for name, field in self.fields.iteritems():
+        for name, field in self.fields.items():
             if isinstance(field, forms.DateField):
                 # Force date format on load, so date picker doesn't mess it up
                 # because of i10n.

--- a/ideascube/library/models.py
+++ b/ideascube/library/models.py
@@ -55,7 +55,7 @@ class Book(SearchMixin, TimeStampedModel):
     class Meta:
         ordering = ['title']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
     def get_absolute_url(self):
@@ -81,7 +81,7 @@ class BookSpecimen(TimeStampedModel):
     def is_digital(self):
         return bool(self.file)
 
-    def __unicode__(self):
+    def __str__(self):
         if self.is_digital:
             # serial is null for digital specimens.
             return u'Digital specimen of "{0}"'.format(self.book)

--- a/ideascube/library/models.py
+++ b/ideascube/library/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from taggit.managers import TaggableManager
 
-from ideascube.models import TimeStampedModel
+from ideascube.models import SortedTaggableManager, TimeStampedModel
 from ideascube.search.models import SearchableQuerySet, SearchMixin
 
 
@@ -50,7 +50,7 @@ class Book(SearchMixin, TimeStampedModel):
                               blank=True)
 
     objects = BookQuerySet.as_manager()
-    tags = TaggableManager(blank=True)
+    tags = TaggableManager(blank=True, manager=SortedTaggableManager)
 
     class Meta:
         ordering = ['title']

--- a/ideascube/library/tests/test_factories.py
+++ b/ideascube/library/tests/test_factories.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.django_db
 def test_it_should_create_a_default_book_from_factory():
     book = BookFactory()
     assert book.pk is not None
-    assert unicode(book)
+    assert str(book)
 
 
 def test_it_should_override_book_fields_passed_to_factory():
@@ -22,7 +22,7 @@ def test_it_should_create_a_default_book_specimen_from_factory():
     specimen = BookSpecimenFactory()
     assert specimen.pk is not None
     assert specimen.book.pk is not None
-    assert unicode(specimen)
+    assert str(specimen)
 
 
 def test_it_should_override_specimen_fields_passed_to_factory():
@@ -36,4 +36,4 @@ def test_it_should_create_a_default_book_digital_specimen_from_factory():
     assert digitalspecimen.pk is not None
     assert digitalspecimen.book.pk is not None
     assert digitalspecimen.file is not None
-    assert unicode(digitalspecimen)
+    assert str(digitalspecimen)

--- a/ideascube/library/tests/test_models.py
+++ b/ideascube/library/tests/test_models.py
@@ -77,4 +77,4 @@ def test_is_not_digital_after_removing_file():
 def test_unicode_returns_digital_specimen_of_book():
     book = BookFactory()
     specimen = BookSpecimenFactory(book=book, is_digital=True)
-    assert unicode(specimen).startswith(u'Digital specimen of')
+    assert str(specimen).startswith(u'Digital specimen of')

--- a/ideascube/library/tests/test_utils.py
+++ b/ideascube/library/tests/test_utils.py
@@ -45,4 +45,4 @@ def test_fetch_from_openlibrary(monkeypatch):
     u'éééé'
 ])
 def test_to_unicode(string):
-    assert isinstance(to_unicode(string), unicode)
+    assert isinstance(to_unicode(string), str)

--- a/ideascube/library/tests/test_views.py
+++ b/ideascube/library/tests/test_views.py
@@ -19,8 +19,8 @@ def test_anonymous_should_access_index_page(app):
 
 def test_only_books_with_specimen_should_be_in_index(app, book, specimen):
     response = app.get(reverse('library:index'))
-    assert specimen.book.title in response.content
-    assert book.title not in response.content
+    assert specimen.book.title in response.content.decode()
+    assert book.title not in response.content.decode()
 
 
 def test_index_page_is_paginated(app, monkeypatch):
@@ -276,8 +276,8 @@ def test_by_tag_page_should_be_filtered_by_tag(app):
     plane = BookSpecimenFactory(book__tags=['plane'])
     boat = BookSpecimenFactory(book__tags=['boat'])
     response = app.get(reverse('library:by_tag', kwargs={'tag': 'plane'}))
-    assert plane.book.title in response.content
-    assert boat.book.title not in response.content
+    assert plane.book.title in response.content.decode()
+    assert boat.book.title not in response.content.decode()
 
 
 def test_by_tag_page_is_paginated(app, monkeypatch):

--- a/ideascube/library/tests/test_views.py
+++ b/ideascube/library/tests/test_views.py
@@ -235,7 +235,7 @@ def test_import_from_files_load_cover_if_exists(staffapp, monkeypatch):
     image = 'ideascube/tests/data/the-prophet.jpg'
     monkeypatch.setattr(
         'ideascube.library.utils.read_url',
-        lambda x: open(image).read()
+        lambda x: open(image, 'rb').read()
     )
     form = staffapp.get(reverse('library:book_import')).forms['import']
     form['from_files'] = Upload('ideascube/library/tests/data/moccam.csv')
@@ -243,7 +243,7 @@ def test_import_from_files_load_cover_if_exists(staffapp, monkeypatch):
     response.follow()
     assert Book.objects.count() == 2
     assert Book.objects.last().cover
-    assert open(Book.objects.last().cover.path).read() == open(image).read()
+    assert open(Book.objects.last().cover.path, 'rb').read() == open(image, 'rb').read()
 
 
 def test_import_from_ideascube_export(staffapp, monkeypatch):

--- a/ideascube/library/utils.py
+++ b/ideascube/library/utils.py
@@ -147,7 +147,7 @@ def load_from_ideascube(content):
             csv_filename = name
             break
     assert csv_filename, _('Missing CSV file in zip')
-    csv_content = load_from_zip(archive, csv_filename)
+    csv_content = load_from_zip(archive, csv_filename).decode('utf-8')
     rows = csv.DictReader(csv_content.splitlines())
     for row in rows:
         cover_filename = row.get('cover')

--- a/ideascube/library/utils.py
+++ b/ideascube/library/utils.py
@@ -147,7 +147,7 @@ def load_from_ideascube(content):
             csv_filename = name
             break
     assert csv_filename, _('Missing CSV file in zip')
-    csv_content = load_from_zip(archive, csv_filename).decode('utf-8')
+    csv_content = load_from_zip(archive, csv_filename).decode()
     rows = csv.DictReader(csv_content.splitlines())
     for row in rows:
         cover_filename = row.get('cover')

--- a/ideascube/library/views.py
+++ b/ideascube/library/views.py
@@ -1,5 +1,5 @@
 import os
-from io import StringIO
+from io import BytesIO
 from zipfile import ZipFile
 
 from django.conf import settings
@@ -150,7 +150,7 @@ class BookExport(CSVExportMixin, View):
               'publisher', 'section', 'lang', 'cover', 'tags']
 
     def get(self, *args, **kwargs):
-        out = StringIO()
+        out = BytesIO()
         self.zip = ZipFile(out, "a")
         csv = self.to_csv()
         self.zip.writestr("{}.csv".format(self.get_filename()), csv)
@@ -177,7 +177,10 @@ class BookExport(CSVExportMixin, View):
                 value = ','.join(book.tags.names())
             else:
                 value = getattr(book, name, None) or ''
-            value = str(value).encode('utf-8')
+
+            if not isinstance(value, str):
+                value = str(value)
+
             row[name] = value
         if book.cover:
             path, ext = os.path.splitext(book.cover.name)

--- a/ideascube/library/views.py
+++ b/ideascube/library/views.py
@@ -1,5 +1,5 @@
 import os
-from StringIO import StringIO
+from io import StringIO
 from zipfile import ZipFile
 
 from django.conf import settings
@@ -92,7 +92,7 @@ class BookImport(FormView):
             try:
                 notices = handler()
             except (ValueError, AssertionError) as e:
-                msg = _(u'Unable to process notices: {}'.format(unicode(e)))
+                msg = _(u'Unable to process notices: {}'.format(str(e)))
                 messages.add_message(self.request, messages.ERROR, msg)
             else:
                 if notices:
@@ -177,7 +177,7 @@ class BookExport(CSVExportMixin, View):
                 value = ','.join(book.tags.names())
             else:
                 value = getattr(book, name, None) or ''
-            value = unicode(value).encode('utf-8')
+            value = str(value).encode('utf-8')
             row[name] = value
         if book.cover:
             path, ext = os.path.splitext(book.cover.name)

--- a/ideascube/management/commands/import_legacy.py
+++ b/ideascube/management/commands/import_legacy.py
@@ -37,7 +37,7 @@ class Authors(models.Model):
         managed = False
         db_table = 'authors'
 
-    def __unicode__(self):
+    def __str__(self):
         return u' '.join([utf8(self.author_rejete), utf8(self.author_name)])
 
 
@@ -82,7 +82,7 @@ class Empr(models.Model):
         managed = False
         db_table = 'empr'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.full_name
         return u'{} {}'.format(utf8(self.empr_prenom), utf8(self.empr_nom))
 
@@ -462,7 +462,7 @@ class Notices(models.Model):
         managed = False
         db_table = 'notices'
 
-    def __unicode__(self):
+    def __str__(self):
         return utf8(self.title)
 
     @property

--- a/ideascube/mediacenter/management/commands/import_medias.py
+++ b/ideascube/mediacenter/management/commands/import_medias.py
@@ -17,8 +17,7 @@ from ideascube.templatetags.ideascube_tags import smart_truncate
 def UnicodeDictReader(utf8_data, encoding='utf-8', **kwargs):
     csv_reader = csv.DictReader(utf8_data, **kwargs)
     for row in csv_reader:
-        yield {key.decode(encoding): value.decode(encoding)
-               for key, value in row.iteritems() if key}
+        yield {key: value for key, value in row.items() if key}
 
 
 class Command(BaseCommand):

--- a/ideascube/mediacenter/management/commands/import_medias.py
+++ b/ideascube/mediacenter/management/commands/import_medias.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import codecs
 import csv
 import mimetypes
 import os
@@ -12,12 +13,6 @@ from ideascube.mediacenter.models import Document
 from ideascube.mediacenter.forms import DocumentForm
 from ideascube.mediacenter.utils import guess_kind_from_content_type
 from ideascube.templatetags.ideascube_tags import smart_truncate
-
-
-def UnicodeDictReader(utf8_data, encoding='utf-8', **kwargs):
-    csv_reader = csv.DictReader(utf8_data, **kwargs)
-    for row in csv_reader:
-        yield {key: value for key, value in row.items() if key}
 
 
 class Command(BaseCommand):
@@ -48,17 +43,13 @@ class Command(BaseCommand):
         self.stdout.write('-' * 20)
 
     def load(self, path):
-        with open(path, 'r') as f:
-            extract = f.read()
+        with codecs.open(path, 'r', encoding=self.encoding) as f:
+            content = f.read()
             try:
-                dialect = csv.Sniffer().sniff(extract)
+                dialect = csv.Sniffer().sniff(content)
             except csv.Error:
                 dialect = csv.unix_dialect()
-            f.seek(0)
-            content = f.read()
-            return UnicodeDictReader(content.splitlines(),
-                                     encoding=self.encoding,
-                                     dialect=dialect)
+            return csv.DictReader(content.splitlines(), dialect=dialect)
 
     def handle(self, *args, **options):
         path = os.path.abspath(options['path'])

--- a/ideascube/mediacenter/models.py
+++ b/ideascube/mediacenter/models.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from taggit.managers import TaggableManager
 
-from ideascube.models import TimeStampedModel
+from ideascube.models import SortedTaggableManager, TimeStampedModel
 from ideascube.search.models import SearchableQuerySet, SearchMixin
 from .utils import guess_kind_from_filename
 
@@ -61,7 +61,7 @@ class Document(SearchMixin, TimeStampedModel):
                             default=OTHER)
 
     objects = DocumentQuerySet.as_manager()
-    tags = TaggableManager(blank=True)
+    tags = TaggableManager(blank=True, manager=SortedTaggableManager)
 
     class Meta:
         ordering = ["-modified_at", ]

--- a/ideascube/mediacenter/models.py
+++ b/ideascube/mediacenter/models.py
@@ -66,7 +66,7 @@ class Document(SearchMixin, TimeStampedModel):
     class Meta:
         ordering = ["-modified_at", ]
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
     def get_absolute_url(self):

--- a/ideascube/mediacenter/tests/test_views.py
+++ b/ideascube/mediacenter/tests/test_views.py
@@ -218,7 +218,7 @@ def test_can_create_document_with_tags(staffapp):
     form.submit().follow()
     doc = Document.objects.last()
     assert doc.tags.count() == 2
-    assert 'tag1' in [t.name for t in doc.tags.all()]
+    assert doc.tags.first().name == 'tag1'
 
 
 def test_can_update_document_tags(staffapp, pdf):
@@ -229,4 +229,4 @@ def test_can_update_document_tags(staffapp, pdf):
     form.submit().follow()
     doc = Document.objects.get(pk=pdf.pk)
     assert doc.tags.count() == 2
-    assert 'tag1' in [t.name for t in doc.tags.all()]
+    assert doc.tags.first().name == 'tag1'

--- a/ideascube/mediacenter/views.py
+++ b/ideascube/mediacenter/views.py
@@ -1,6 +1,6 @@
 import json
 
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.urlresolvers import reverse_lazy, resolve, Resolver404

--- a/ideascube/mixins.py
+++ b/ideascube/mixins.py
@@ -1,5 +1,5 @@
 import csv
-import StringIO
+from io import StringIO
 from datetime import datetime
 
 from django.conf import settings
@@ -28,7 +28,7 @@ class CSVExportMixin(object):
     prefix = 'ideascube'
 
     def to_csv(self):
-        out = StringIO.StringIO()
+        out = StringIO()
         headers = self.get_headers()
         writer = csv.DictWriter(out, headers)
         writer.writeheader()

--- a/ideascube/models.py
+++ b/ideascube/models.py
@@ -77,7 +77,7 @@ class User(SearchMixin, TimeStampedModel, AbstractBaseUser):
     class Meta:
         ordering = ["-modified_at"]
 
-    def __unicode__(self):
+    def __str__(self):
         return self.get_full_name() or self.serial
 
     def get_absolute_url(self):
@@ -135,7 +135,7 @@ class User(SearchMixin, TimeStampedModel, AbstractBaseUser):
 
     @property
     def index_strings(self):
-        return (unicode(getattr(self, name, ''))
+        return (str(getattr(self, name, ''))
                 for name in settings.USER_INDEX_FIELDS)
 
     index_public = False  # Searchable only by staff.

--- a/ideascube/models.py
+++ b/ideascube/models.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_countries.fields import CountryField
+from taggit.managers import _TaggableManager
 
 from ideascube.search.models import SearchMixin, SearchableQuerySet
 
@@ -269,3 +270,9 @@ class User(SearchMixin, TimeStampedModel, AbstractBaseUser):
     sw_level = CommaSeparatedCharField(
         _('Swahili knowledge'), choices=LANG_KNOWLEDGE_CHOICES,
         blank=True, max_length=32)
+
+
+class SortedTaggableManager(_TaggableManager):
+    def get_queryset(self, *args, **kwargs):
+        qs = super().get_queryset(*args, **kwargs)
+        return qs.order_by('name')

--- a/ideascube/monitoring/models.py
+++ b/ideascube/monitoring/models.py
@@ -67,7 +67,7 @@ class StockItem(models.Model):
     name = models.CharField(_('name'), max_length=150)
     description = models.TextField(_('description'), blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def get_absolute_url(self):

--- a/ideascube/monitoring/tests/test_views.py
+++ b/ideascube/monitoring/tests/test_views.py
@@ -71,8 +71,9 @@ def test_export_entry_should_return_csv_with_entries(staffapp, settings):
     EntryFactory.create_batch(3)
     settings.MONITORING_ENTRY_EXPORT_FIELDS = []
     resp = staffapp.get(reverse('monitoring:export_entry'), status=200)
-    assert resp.content.startswith("module,date,activity,partner\r\ncinema,")
-    assert resp.content.count("cinema") == 3
+    content = resp.content.decode()
+    assert content.startswith("module,date,activity,partner\r\ncinema,")
+    assert content.count("cinema") == 3
 
 
 def test_anonymous_should_not_access_stock_page(app):
@@ -210,7 +211,7 @@ def test_can_export_inventory(staffapp):
     InventorySpecimen.objects.create(inventory=inventory, specimen=specimen)
     url = reverse('monitoring:inventory_export', kwargs={'pk': inventory.pk})
     resp = staffapp.get(url, status=200)
-    assert resp.content.startswith("module,name,description,barcode,serial,count,comments,status\r\ncinema,an item")  # noqa
+    assert resp.content.decode().startswith("module,name,description,barcode,serial,count,comments,status\r\ncinema,an item")  # noqa
 
 
 def test_export_inventory_should_be_ok_in_arabic(staffapp, settings):
@@ -400,7 +401,7 @@ def test_can_export_loan(staffapp):
     LoanFactory(specimen=specimen)
     url = reverse('monitoring:export_loan')
     resp = staffapp.get(url, status=200)
-    assert resp.content.startswith("item,barcode,user,loaned at,due date,returned at,comments\r\nan item,123")  # noqa
+    assert resp.content.decode().startswith("item,barcode,user,loaned at,due date,returned at,comments\r\nan item,123")  # noqa
 
 
 def test_export_loan_should_be_ok_in_arabic(staffapp):
@@ -409,6 +410,6 @@ def test_export_loan_should_be_ok_in_arabic(staffapp):
     loan = LoanFactory(specimen=specimen, comments=u"النبي (كتاب)")
     url = reverse('monitoring:export_loan')
     resp = staffapp.get(url, status=200)
-    assert resp.content.startswith("item,barcode,user,loaned at,due date,returned at,comments\r\nan item,123")  # noqa
+    assert resp.content.decode().startswith("item,barcode,user,loaned at,due date,returned at,comments\r\nan item,123")  # noqa
     resp.mustcontain(loan.comments)
     translation.deactivate()

--- a/ideascube/monitoring/views.py
+++ b/ideascube/monitoring/views.py
@@ -401,7 +401,7 @@ class ExportLoan(CSVExportMixin, View):
 
     def get_row(self, entry):
         return {
-            'item': unicode(entry.specimen.item).encode('utf-8'),
+            'item': str(entry.specimen.item).encode('utf-8'),
             'barcode': entry.specimen.barcode,
             'user': entry.user.serial.encode('utf-8'),
             'loaned at': entry.created_at,

--- a/ideascube/monitoring/views.py
+++ b/ideascube/monitoring/views.py
@@ -174,12 +174,12 @@ class InventoryExport(CSVExportMixin, DetailView):
     def get_row(self, specimen):
         return {
             'module': specimen.item.module,
-            'name': specimen.item.name.encode('utf-8'),
-            'description': specimen.item.description.encode('utf-8'),
+            'name': specimen.item.name,
+            'description': specimen.item.description,
             'barcode': specimen.barcode,
             'serial': specimen.serial,
             'count': specimen.count,
-            'comments': specimen.comments.encode('utf-8'),
+            'comments': specimen.comments,
             'status': specimen.count if specimen in self.object else 'ko'
         }
 
@@ -401,13 +401,13 @@ class ExportLoan(CSVExportMixin, View):
 
     def get_row(self, entry):
         return {
-            'item': str(entry.specimen.item).encode('utf-8'),
+            'item': str(entry.specimen.item),
             'barcode': entry.specimen.barcode,
-            'user': entry.user.serial.encode('utf-8'),
+            'user': entry.user.serial,
             'loaned at': entry.created_at,
             'due date': entry.due_date,
             'returned at': entry.returned_at,
-            'comments': entry.comments.encode('utf-8')
+            'comments': entry.comments
         }
 
 export_loan = staff_member_required(ExportLoan.as_view())

--- a/ideascube/search/tests/test_views.py
+++ b/ideascube/search/tests/test_views.py
@@ -14,7 +14,7 @@ def test_search_view_should_show_results(app):
     form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title in page.content
+    assert content.title in page.content.decode()
 
 
 def test_search_view_should_not_return_draft_content_to_anonymous(app):
@@ -22,7 +22,7 @@ def test_search_view_should_not_return_draft_content_to_anonymous(app):
     form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title not in page.content
+    assert content.title not in page.content.decode()
 
 
 def test_search_view_should_not_return_deleted_content_to_anonymous(app):
@@ -30,7 +30,7 @@ def test_search_view_should_not_return_deleted_content_to_anonymous(app):
     form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title not in page.content
+    assert content.title not in page.content.decode()
 
 
 def test_search_view_should_not_return_draft_content_to_logged_user(loggedapp):
@@ -38,7 +38,7 @@ def test_search_view_should_not_return_draft_content_to_logged_user(loggedapp):
     form = loggedapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title not in page.content
+    assert content.title not in page.content.decode()
 
 
 def test_search_view_should_not_return_deleted_to_logged_user(loggedapp):
@@ -46,7 +46,7 @@ def test_search_view_should_not_return_deleted_to_logged_user(loggedapp):
     form = loggedapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title not in page.content
+    assert content.title not in page.content.decode()
 
 
 def test_search_view_should_return_draft_content_to_staff_user(staffapp):
@@ -54,7 +54,7 @@ def test_search_view_should_return_draft_content_to_staff_user(staffapp):
     form = staffapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title in page.content
+    assert content.title in page.content.decode()
 
 
 def test_search_view_should_not_return_deleted_to_staff_user(staffapp):
@@ -62,7 +62,7 @@ def test_search_view_should_not_return_deleted_to_staff_user(staffapp):
     form = staffapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title in page.content
+    assert content.title in page.content.decode()
 
 
 def test_search_view_should_return_mixed_content(app):
@@ -71,5 +71,5 @@ def test_search_view_should_return_mixed_content(app):
     form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
-    assert content.title in page.content
-    assert book.title in page.content
+    assert content.title in page.content.decode()
+    assert book.title in page.content.decode()

--- a/ideascube/serveradmin/tests/test_views.py
+++ b/ideascube/serveradmin/tests/test_views.py
@@ -327,7 +327,7 @@ def test_upload_button_do_not_create_backup_with_non_zip_file(staffapp,
     backup_path = os.path.join(BACKUPS_ROOT, backup_name)
     assert not os.path.exists(backup_path)
     form = staffapp.get(reverse('server:backup')).forms['backup']
-    form['upload'] = Upload(backup_name, 'xxx')
+    form['upload'] = Upload(backup_name, b'xxx')
     resp = form.submit('do_upload')
     assert resp.status_code == 200
     assert not os.path.exists(backup_path)

--- a/ideascube/serveradmin/views.py
+++ b/ideascube/serveradmin/views.py
@@ -80,7 +80,7 @@ def backup(request):
                     backup = Backup.load(file_)
                 except Exception as e:
                     msg = _('Unable to load file:')
-                    msg = "{msg} {error}".format(msg=msg, error=e.message)
+                    msg = "{msg} {error}".format(msg=msg, error=str(e))
                     messages.add_message(request, messages.ERROR, msg)
                 else:
                     msg = _('File {name} has been loaded.').format(

--- a/ideascube/templatetags/ideascube_tags.py
+++ b/ideascube/templatetags/ideascube_tags.py
@@ -127,6 +127,6 @@ def smart_truncate(s, length=100, suffix=u'…'):
 @register.simple_tag
 def paginate(request, **kwargs):
     get = request.GET.copy()
-    for key, value in kwargs.iteritems():
+    for key, value in kwargs.items():
         get[key] = value
     return '?{}'.format(get.urlencode())

--- a/ideascube/tests/test_factories.py
+++ b/ideascube/tests/test_factories.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.django_db
 def test_it_should_create_a_default_user_from_factory():
     user = UserFactory()
     assert user.pk is not None
-    assert unicode(user)
+    assert str(user)
 
 
 def test_it_should_override_fields_passed_to_factory():

--- a/ideascube/tests/test_models.py
+++ b/ideascube/tests/test_models.py
@@ -41,7 +41,7 @@ def test_user_data_fields_should_return_labels_and_values():
     user = User(short_name='my name', ar_level=['u', 's'])
     fields = user.data_fields
     assert 'is_staff' not in fields
-    assert fields['short_name']['value'] == 'my name'
-    assert fields['short_name']['label'] == 'usual name'
-    assert fields['ar_level']['value'] == 'Understood, Spoken'
-    assert unicode(fields['ar_level']['label']) == 'Arabic knowledge'
+    assert str(fields['short_name']['value']) == 'my name'
+    assert str(fields['short_name']['label']) == 'usual name'
+    assert str(fields['ar_level']['value']) == 'Understood, Spoken'
+    assert str(fields['ar_level']['label']) == 'Arabic knowledge'

--- a/ideascube/tests/test_views.py
+++ b/ideascube/tests/test_views.py
@@ -340,13 +340,13 @@ def test_export_users_should_return_csv_with_users(staffapp, settings):
 
 def test_export_users_should_be_ok_in_arabic(staffapp, settings):
     translation.activate('ar')
-    user1 = UserFactory(serial=u"جبران خليل جبران")
-    user2 = UserFactory(serial=u"النبي (كتاب)")
+    user1 = UserFactory(serial="جبران خليل جبران")
+    user2 = UserFactory(serial="النبي (كتاب)")
     resp = staffapp.get(reverse('user_export'), status=200)
     field, _, _, _ = user_model._meta.get_field_by_name('serial')
     resp.mustcontain(str(field.verbose_name))
-    resp.mustcontain(user1.serial.encode())
-    resp.mustcontain(user2.serial.encode())
+    resp.mustcontain(user1.serial)
+    resp.mustcontain(user2.serial)
     translation.deactivate()
 
 

--- a/ideascube/tests/test_views.py
+++ b/ideascube/tests/test_views.py
@@ -64,12 +64,12 @@ def test_welcome_page_should_create_staff_user_on_POST(app):
 
 def test_welcome_page_should_create_staff_user_with_unicode(app):
     form = app.get(reverse('welcome_staff')).forms['model_form']
-    name = u'كتبه'
+    name = 'كتبه'
     form['serial'] = name
     form['password'] = 'password'
     form['password_confirm'] = 'password'
     response = form.submit().follow().follow()
-    response.mustcontain(name)
+    response.mustcontain(name.encode())
 
 
 def test_login_page_should_log_in_user_if_POST_data_is_correct(client, user,
@@ -116,7 +116,7 @@ def test_non_staff_should_not_access_user_list_page(loggedapp):
 
 def test_user_list_page_should_be_accessible_to_staff(staffapp, user):
     response = staffapp.get(reverse('user_list'), status=200)
-    response.mustcontain(unicode(user))
+    response.mustcontain(str(user))
 
 
 def test_user_list_page_is_paginated(staffapp, monkeypatch):
@@ -137,7 +137,7 @@ def test_user_list_page_should_be_searchable(staffapp):
     user1 = UserFactory(full_name="user1")
     user2 = UserFactory(full_name="user2")
     response = staffapp.get(reverse('user_list') + '?q=user1')
-    response.mustcontain(unicode(user1), no=unicode(user2))
+    response.mustcontain(str(user1), no=str(user2))
 
 
 def test_user_detail_page_should_not_be_accessible_to_anonymous(app, user):
@@ -152,7 +152,7 @@ def test_non_staff_should_not_access_user_detail_page(loggedapp, user):
 
 def test_user_detail_page_should_be_accessible_to_staff(staffapp, user):
     response = staffapp.get(reverse('user_detail', kwargs={'pk': user.pk}))
-    response.mustcontain(unicode(user))
+    response.mustcontain(str(user))
 
 
 def test_user_create_page_should_not_be_accessible_to_anonymous(app):
@@ -344,9 +344,9 @@ def test_export_users_should_be_ok_in_arabic(staffapp, settings):
     user2 = UserFactory(serial=u"النبي (كتاب)")
     resp = staffapp.get(reverse('user_export'), status=200)
     field, _, _, _ = user_model._meta.get_field_by_name('serial')
-    resp.mustcontain(unicode(field.verbose_name))
-    resp.mustcontain(user1.serial)
-    resp.mustcontain(user2.serial)
+    resp.mustcontain(str(field.verbose_name))
+    resp.mustcontain(user1.serial.encode())
+    resp.mustcontain(user2.serial.encode())
     translation.deactivate()
 
 
@@ -407,7 +407,7 @@ def test_valid_proxy_request(app):
     environ = {'SERVER_NAME': 'testserver'}
     response = app.get(url, params, headers, environ)
     assert response.status_code == 200
-    assert 'Example Domain' in response.content
+    assert 'Example Domain' in response.content.decode()
     assert "Vary" not in response.headers
 
 
@@ -417,10 +417,10 @@ def test_by_tag_page_should_be_filtered_by_tag(app):
     plane2 = BookSpecimenFactory(book__tags=['plane'])
     boat2 = BookSpecimenFactory(book__tags=['boat'])
     response = app.get(reverse('by_tag', kwargs={'tag': 'plane'}))
-    assert plane.title in response.content
-    assert plane2.book.title in response.content
-    assert boat.title not in response.content
-    assert boat2.book.title not in response.content
+    assert plane.title in response.content.decode()
+    assert plane2.book.title in response.content.decode()
+    assert boat.title not in response.content.decode()
+    assert boat2.book.title not in response.content.decode()
 
 
 def test_by_tag_page_is_paginated(app, monkeypatch):

--- a/ideascube/views.py
+++ b/ideascube/views.py
@@ -178,7 +178,7 @@ class UserExport(CSVExportMixin, View):
     def get_headers(self):
         fields = user_model.get_data_fields()
         self.fields = [f for f in fields if f.name not in user_model.PRIVATE_DATA]
-        return [str(f.verbose_name).encode('utf-8') for f in self.fields]
+        return [str(f.verbose_name) for f in self.fields]
 
     def get_row(self, user):
         data_fields = user.data_fields
@@ -187,8 +187,8 @@ class UserExport(CSVExportMixin, View):
             value = data_fields[field.name]['value']
             if value is None:
                 value = ''
-            value = str(value).encode('utf-8')
-            row[str(field.verbose_name).encode('utf-8')] = value
+            value = str(value)
+            row[str(field.verbose_name)] = value
         return row
 user_export = staff_member_required(UserExport.as_view())
 

--- a/ideascube/views.py
+++ b/ideascube/views.py
@@ -1,7 +1,8 @@
 import mimetypes
 import socket
-import urllib2
-from urlparse import urlparse
+from urllib.parse import urlparse
+from urllib.request import Request, build_opener
+from urllib.error import HTTPError
 
 from django.conf import settings
 from django.contrib import messages
@@ -177,7 +178,7 @@ class UserExport(CSVExportMixin, View):
     def get_headers(self):
         fields = user_model.get_data_fields()
         self.fields = [f for f in fields if f.name not in user_model.PRIVATE_DATA]
-        return [unicode(f.verbose_name).encode('utf-8') for f in self.fields]
+        return [str(f.verbose_name).encode('utf-8') for f in self.fields]
 
     def get_row(self, user):
         data_fields = user.data_fields
@@ -186,8 +187,8 @@ class UserExport(CSVExportMixin, View):
             value = data_fields[field.name]['value']
             if value is None:
                 value = ''
-            value = unicode(value).encode('utf-8')
-            row[unicode(field.verbose_name).encode('utf-8')] = value
+            value = str(value).encode('utf-8')
+            row[str(field.verbose_name).encode('utf-8')] = value
         return row
 user_export = staff_member_required(UserExport.as_view())
 
@@ -230,17 +231,16 @@ class AjaxProxy(View):
         headers = {
             'User-Agent': 'ideascube +http://ideas-box.org'
         }
-        request = urllib2.Request(url, headers=headers)
-        opener = urllib2.build_opener()
+        request = Request(url, headers=headers)
+        opener = build_opener()
         try:
             proxied_request = opener.open(request)
-        except urllib2.HTTPError as e:
+        except HTTPError as e:
             return HttpResponse(e.msg, status=e.code,
                                 content_type='text/plain')
         else:
             status_code = proxied_request.code
-            mimetype = (proxied_request.headers.typeheader
-                        or mimetypes.guess_type(url))
+            mimetype = proxied_request.headers.get('Content-Type') or mimetypes.guess_type(url)  # noqa
             content = proxied_request.read()
             # Quick hack to prevent Django from adding a Vary: Cookie header
             self.request.session.accessed = False


### PR DESCRIPTION
This moves Ideascube completely over to Python 3.

These changes do **not** preserve compatibility with Python 2 at all.

The unit tests all pass (including in Travis), and the Debian packaging configuration is also updated.

Fixes #75 