### PR TITLE
systemd: Fix bytes/unicode issue

### DIFF
--- a/ideascube/serveradmin/systemd.py
+++ b/ideascube/serveradmin/systemd.py
@@ -95,6 +95,6 @@ def systemctl(action, unit):
         msg = ["Could not %s %s" % (action, unit)]
 
         if err:
-            msg.append(err.strip())
+            msg.append(err.strip().decode())
 
         raise UnitManagementError(': '.join(msg))

--- a/ideascube/serveradmin/tests/__init__.py
+++ b/ideascube/serveradmin/tests/__init__.py
@@ -109,7 +109,7 @@ class FakePopen(object):
 
     def communicate(self):
         if self.returncode and self.stderr is not None:
-            self.stderr.write(u'Oh Noes!')
+            self.stderr.write(b'Oh Noes!')
 
         return self.stdout.getvalue(), self.stderr.getvalue()
 

--- a/ideascube/serveradmin/tests/test_systemd.py
+++ b/ideascube/serveradmin/tests/test_systemd.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO
 
 import pytest
 
@@ -44,7 +44,7 @@ def test_activate_service(mocker):
     mocker.patch(
         'ideascube.serveradmin.systemd.subprocess.Popen', side_effect=FakePopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     manager = Manager()
     manager.activate('NetworkManager.service')
@@ -59,7 +59,7 @@ def test_failed_to_activate_service(mocker):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FailingPopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     manager = Manager()
 
@@ -78,7 +78,7 @@ def test_deactivate_service(mocker):
     mocker.patch(
         'ideascube.serveradmin.systemd.subprocess.Popen', side_effect=FakePopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     manager = Manager()
     manager.deactivate('NetworkManager.service')
@@ -93,7 +93,7 @@ def test_failed_to_deactivate_service(mocker):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FailingPopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     manager = Manager()
 
@@ -112,7 +112,7 @@ def test_restart_service(mocker):
     mocker.patch(
         'ideascube.serveradmin.systemd.subprocess.Popen', side_effect=FakePopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     manager = Manager()
     manager.restart('NetworkManager.service')

--- a/ideascube/serveradmin/tests/test_views.py
+++ b/ideascube/serveradmin/tests/test_views.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO
 import os
 import shutil
 import zipfile
@@ -112,7 +112,7 @@ def test_staff_activates_service(mocker, staffapp, settings):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FakePopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     settings.SERVICES = [{'name': 'nginx'}]
 
@@ -131,7 +131,7 @@ def test_staff_fails_to_activate_service(mocker, staffapp, settings):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FailingPopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     settings.SERVICES = [{'name': 'nginx'}]
 
@@ -150,7 +150,7 @@ def test_staff_deactivates_service(mocker, staffapp, settings):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FakePopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     settings.SERVICES = [{'name': 'NetworkManager'}]
 
@@ -169,7 +169,7 @@ def test_staff_fails_to_deactivate_service(mocker, staffapp, settings):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FailingPopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     settings.SERVICES = [{'name': 'NetworkManager'}]
 
@@ -188,7 +188,7 @@ def test_staff_restarts_service(mocker, staffapp, settings):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FakePopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     settings.SERVICES = [{'name': 'NetworkManager'}]
 
@@ -207,7 +207,7 @@ def test_staff_fails_to_restart_service(mocker, staffapp, settings):
         'ideascube.serveradmin.systemd.subprocess.Popen',
         side_effect=FailingPopen)
     mocker.patch(
-        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=StringIO)
+        'ideascube.serveradmin.systemd.subprocess.PIPE', side_effect=BytesIO)
 
     settings.SERVICES = [{'name': 'NetworkManager'}]
 


### PR DESCRIPTION
The problem is that the stdout and stderr of a subprocess.Popen call are bytes, not unicode.

And then in the code, we mix that with string literals... which were bytes in Python2, but unicode in Python3.

The unit tests never found the problem, because we mock the Popen and its stdout/stderr, replacing the latter by StringIO.

And in Python3, StringIO take unicode, not bytes, so everything was just fine for the unit tests.

