### PR TITLE
wifi: Fix traceback

### DIFF
--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -137,6 +137,7 @@ class AvailableWifiNetwork(object):
             attempt += 1
 
         self._connection.forget()
+        self._connection = None
         raise WifiError(_('Failed to connect to %s') % self.ssid)
 
     @property


### PR DESCRIPTION
In cc2dcd1e4da394c7bff98e499649d3cfb238cd24, we introduced a dirty hack to work around the fact that we talk to NetworkManager over DBus using an asynchronous API, but we need a synchronous response about whether we connected or not.

To refresh our collective memory, after that change we now just try checking whether we are connected over and over again, waiting one second between each check.

That loop either stops when we are connected, or after 6 attempts, whichever comes first.

And if after 6 attempts we're still not connected, then we consider that NM failed to connect, and we just delete the NM Connection object.

After that, we try to display the wifi page, with an error about how we couldn't connect.

And when displaying the wifi page, we try to check whether we are connected to each network we display, so that we can put a little checkmark next to the network SSID.

And that fails for the network we had tried to connect to... because we deleted the connection object, but it thinks it still has one.

This commit « fixes » that, by resetting the network's connection object to None, so that it knows not to check whether we're connected to it.

Of course, this is all entirely awful and one day we'll need to bite the bullet and figure out how we want to handle asynchronous APIs like this one properly.

But for now, ship it!