### PR TITLE
Remove STORAGE_ROOT var from kb.py

### DIFF
--- a/ideascube/conf/kb.py
+++ b/ideascube/conf/kb.py
@@ -2,7 +2,6 @@ from .base import *  # noqa
 
 ALLOWED_HOSTS = ['.koombook.lan.', 'localhost', '127.0.0.1']
 TIME_ZONE = None
-STORAGE_ROOT = '/media/hdd/ideascube/storage'
 DOMAIN = 'koombook.lan'
 BACKUP_FORMAT = 'gztar'
 IDEASCUBE_BODY_ID = 'koombook'


### PR DESCRIPTION
I think we can now remove the STORAGE_ROOT variable from the config file, indeed, we are now using a symlink from /var/ideascube pointing to /media/hdd/ideascube (koombook only). This is also fixing the process of installation as I had rights conflicts with the SQLite DB. I have tested it on KoomBook and it's working fine!