### PR TITLE
Increase number of attemps on wifi module

### DIFF
--- a/ideascube/serveradmin/wifi.py
+++ b/ideascube/serveradmin/wifi.py
@@ -129,7 +129,7 @@ class AvailableWifiNetwork(object):
         attempt = 1
         import time
 
-        while attempt < 7:
+        while attempt < 12:
             if self.connected:
                 return
 


### PR DESCRIPTION
I would suggest to increase the number of attempts to 12. Indeed, the connexion sometime FAILED because the number is too low. After several test it seems that 12 is a good enough value. There is still some random FAILING but it is better.