### PR TITLE
Catalog: more defensive approach

### DIFF
--- a/ideascube/library/migrations/0005_merge.py
+++ b/ideascube/library/migrations/0005_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('library', '0004_auto_20160310_1830'),
+        ('library', '0004_auto_20160322_1502'),
+    ]
+
+    operations = [
+    ]

--- a/ideascube/mediacenter/migrations/0009_merge.py
+++ b/ideascube/mediacenter/migrations/0009_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mediacenter', '0006_auto_20160310_1830'),
+        ('mediacenter', '0008_auto_20160322_1502'),
+    ]
+
+    operations = [
+    ]

--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -20,6 +20,14 @@ from .systemd import Manager as SystemManager, NoSuchUnit
 from ..utils import printerr
 
 
+def rm(path):
+    try:
+        os.unlink(path)
+
+    except IsADirectoryError:
+        shutil.rmtree(path)
+
+
 class InvalidFile(Exception):
     pass
 
@@ -253,6 +261,8 @@ class ZippedZim(Package):
 
         for path in glob(os.path.join(datadir, '*', '{}*'.format(zimname))):
             new = path.replace(zimname, '{0.id}.zim'.format(self))
+            if Path(new).exists():
+                rm(new)
             os.rename(path, new)
 
     def remove(self, install_dir):
@@ -260,11 +270,7 @@ class ZippedZim(Package):
         datadir = os.path.join(install_dir, 'data')
 
         for path in glob(os.path.join(datadir, '*', zimname)):
-            try:
-                os.unlink(path)
-
-            except IsADirectoryError:
-                shutil.rmtree(path)
+            rm(path)
 
 
 class StaticSite(Package):
@@ -429,16 +435,30 @@ class Catalog:
 
     def install_packages(self, ids):
         used_handlers = {}
+        downloaded = []
 
         for pkg in self._get_packages(ids, self._catalog['available']):
             if pkg.id in self._catalog['installed']:
                 printerr('{0.id} is already installed'.format(pkg))
                 continue
 
-            download_path = self._fetch_package(pkg)
+            try:
+                download_path = self._fetch_package(pkg)
+            except DownloadError as e:
+                printerr("Failed downloading {0.id}".format(pkg))
+                printerr(e)
+            else:
+                downloaded.append((pkg, download_path))
+
+        for pkg, download_path in downloaded:
             handler = self._get_handler(pkg)
             print('Installing {0.id}'.format(pkg))
-            handler.install(pkg, download_path)
+            try:
+                handler.install(pkg, download_path)
+            except Exception as e:
+                printerr("Failed installing {0.id}".format(pkg))
+                printerr(e)
+                continue
             used_handlers[handler.__class__.__name__] = handler
             self._catalog['installed'][pkg.id] = (
                 self._catalog['available'][pkg.id])
@@ -453,7 +473,12 @@ class Catalog:
         for pkg in self._get_packages(ids, self._catalog['installed']):
             handler = self._get_handler(pkg)
             print('Removing {0.id}'.format(pkg))
-            handler.remove(pkg)
+            try:
+                handler.remove(pkg)
+            except Exception as e:
+                printerr("Failed removing {0.id}".format(pkg))
+                printerr(e)
+                continue
             used_handlers[handler.__class__.__name__] = handler
             del(self._catalog['installed'][pkg.id])
             self._persist_cache()
@@ -463,6 +488,7 @@ class Catalog:
 
     def upgrade_packages(self, ids):
         used_handlers = {}
+        downloaded = []
 
         for ipkg in self._get_packages(ids, self._catalog['installed']):
             upkg = self._get_package(ipkg.id, self._catalog['available'])
@@ -471,15 +497,33 @@ class Catalog:
                 printerr('{0.id} has no update available'.format(ipkg))
                 continue
 
-            download_path = self._fetch_package(upkg)
+            try:
+                download_path = self._fetch_package(upkg)
+            except DownloadError as e:
+                printerr("Failed downloading {0.id}".format(upkg))
+                printerr(e)
+            else:
+                downloaded.append((ipkg, upkg, download_path))
+
+        for ipkg, upkg, download_path in downloaded:
             ihandler = self._get_handler(ipkg)
             uhandler = self._get_handler(upkg)
             print('Upgrading {0.id}'.format(ipkg))
 
-            ihandler.remove(ipkg)
+            try:
+                ihandler.remove(ipkg)
+            except Exception as e:
+                printerr("Failed removing {0.id}".format(ipkg))
+                printerr(e)
+                continue
             used_handlers[ihandler.__class__.__name__] = ihandler
 
-            uhandler.install(upkg, download_path)
+            try:
+                uhandler.install(upkg, download_path)
+            except Exception as e:
+                printerr("Failed installing {0.id}\n".format(upkg))
+                printerr(e)
+                continue
             used_handlers[uhandler.__class__.__name__] = uhandler
 
             self._catalog['installed'][ipkg.id] = (

--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -261,9 +261,11 @@ class ZippedZim(Package):
 
         for path in glob(os.path.join(datadir, '*', '{}*'.format(zimname))):
             new = path.replace(zimname, '{0.id}.zim'.format(self))
-            if Path(new).exists():
+            try:
+                os.rename(path, new)
+            except OSError:
                 rm(new)
-            os.rename(path, new)
+                os.rename(path, new)
 
     def remove(self, install_dir):
         zimname = '{0.id}.zim*'.format(self)

--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -442,11 +442,10 @@ class Catalog:
             used_handlers[handler.__class__.__name__] = handler
             self._catalog['installed'][pkg.id] = (
                 self._catalog['available'][pkg.id])
+            self._persist_cache()
 
         for handler in used_handlers.values():
             handler.commit()
-
-        self._persist_cache()
 
     def remove_packages(self, ids):
         used_handlers = {}
@@ -457,11 +456,10 @@ class Catalog:
             handler.remove(pkg)
             used_handlers[handler.__class__.__name__] = handler
             del(self._catalog['installed'][pkg.id])
+            self._persist_cache()
 
         for handler in used_handlers.values():
             handler.commit()
-
-        self._persist_cache()
 
     def upgrade_packages(self, ids):
         used_handlers = {}
@@ -486,11 +484,10 @@ class Catalog:
 
             self._catalog['installed'][ipkg.id] = (
                 self._catalog['available'][upkg.id])
+            self._persist_cache()
 
         for handler in used_handlers.values():
             handler.commit()
-
-        self._persist_cache()
 
     # -- Manage local cache ---------------------------------------------------
     def _load_cache(self):

--- a/ideascube/serveradmin/tests/test_catalog.py
+++ b/ideascube/serveradmin/tests/test_catalog.py
@@ -353,6 +353,22 @@ def test_kiwix_installs_zippedzim(tmpdir, settings, zippedzim_path):
     assert index.join('{}.zim.idx'.format(p.id)).check(dir=True)
 
 
+def test_kiwix_does_not_fail_if_files_already_exist(tmpdir, settings,
+                                                    zippedzim_path):
+    from ideascube.serveradmin.catalog import Kiwix, ZippedZim
+
+    settings.CATALOG_KIWIX_INSTALL_DIR = tmpdir.strpath
+
+    p = ZippedZim('wikipedia.tum', {
+        'url': 'https://foo.fr/wikipedia_tum_all_nopic_2015-08.zim'})
+    h = Kiwix()
+    h.install(p, zippedzim_path.strpath)
+    h.install(p, zippedzim_path.strpath)
+
+    data = tmpdir.join('data')
+    assert data.check(dir=True)
+
+
 def test_kiwix_removes_zippedzim(tmpdir, settings, zippedzim_path):
     from ideascube.serveradmin.catalog import Kiwix, ZippedZim
 


### PR DESCRIPTION
This PR does four things:

- when installing a zim, always override any preexisting content (and do not fail)
- persist cache as soon as a package is marked as installed/removed
- download all packages then install all packages instead of doing download/install by package
- catch download/install/remove errors and continue to the next id to be processed (instead of failing)

cf #326