### PR TITLE
catalog: Allow reinstalling packages

### DIFF
--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -116,6 +116,7 @@ class Kiwix(Handler):
         print('Rebuilding the Kiwix library')
         library = etree.Element('library')
         libdir = os.path.join(self._install_dir, 'data', 'library')
+        os.makedirs(libdir, exist_ok=True)
 
         for libpath in glob(os.path.join(libdir, '*.xml')):
             zimname = os.path.basename(libpath)[:-4]
@@ -472,7 +473,7 @@ class Catalog:
         for handler in used_handlers.values():
             handler.commit()
 
-    def remove_packages(self, ids):
+    def remove_packages(self, ids, commit=True):
         used_handlers = {}
 
         for pkg in self._get_packages(ids, self._catalog['installed']):
@@ -488,8 +489,15 @@ class Catalog:
             del(self._catalog['installed'][pkg.id])
             self._persist_cache()
 
+        if not commit:
+            return
+
         for handler in used_handlers.values():
             handler.commit()
+
+    def reinstall_packages(self, ids):
+        self.remove_packages(ids, commit=False)
+        self.install_packages(ids)
 
     def upgrade_packages(self, ids):
         used_handlers = {}

--- a/ideascube/serveradmin/management/commands/catalog.py
+++ b/ideascube/serveradmin/management/commands/catalog.py
@@ -54,6 +54,11 @@ class Command(BaseCommand):
             help='Install packages')
         install.set_defaults(func=self.install_packages)
 
+        reinstall = subs.add_parser(
+            'reinstall', parents=[package_cache, required_ids],
+            help='Reinstall packages')
+        reinstall.set_defaults(func=self.reinstall_packages)
+
         remove = subs.add_parser(
             'remove', parents=[required_ids], help='Remove packages')
         remove.set_defaults(func=self.remove_packages)
@@ -156,6 +161,13 @@ class Command(BaseCommand):
     def remove_packages(self, options):
         try:
             self.catalog.remove_packages(options['ids'])
+
+        except NoSuchPackage as e:
+            raise CommandError('No such package: {}'.format(e))
+
+    def reinstall_packages(self, options):
+        try:
+            self.catalog.reinstall_packages(oprions['ids'])
 
         except NoSuchPackage as e:
             raise CommandError('No such package: {}'.format(e))

--- a/ideascube/serveradmin/tests/test_catalog.py
+++ b/ideascube/serveradmin/tests/test_catalog.py
@@ -1227,6 +1227,67 @@ def test_catalog_install_package_with_unknown_type(
         c.install_packages(['wikipedia.tum'])
 
 
+def test_catalog_reinstall_package(tmpdir, settings, testdatadir, mocker):
+    from ideascube.serveradmin.catalog import Catalog
+
+    cachedir = tmpdir.mkdir('cache')
+    installdir = tmpdir.mkdir('kiwix')
+    sourcedir = tmpdir.mkdir('source')
+
+    zippedzim = testdatadir.join('catalog', 'wikipedia.tum-2015-08')
+    path = sourcedir.join('wikipedia_tum_all_nopic_2015-08.zim')
+    zippedzim.copy(path)
+
+    remote_catalog_file = sourcedir.join('catalog.yml')
+    with remote_catalog_file.open(mode='w') as f:
+        f.write('all:\n')
+        f.write('  wikipedia.tum:\n')
+        f.write('    version: 2015-08\n')
+        f.write('    size: 200KB\n')
+        f.write('    url: file://{}\n'.format(path))
+        f.write(
+            '    sha256sum: 335d00b53350c63df45486c5433205f068ad90e33c208064b'
+            '212c29a30109c54\n')
+        f.write('    type: zipped-zim\n')
+        f.write('    handler: kiwix\n')
+
+    mocker.patch('ideascube.serveradmin.catalog.SystemManager')
+    mocker.patch(
+        'ideascube.serveradmin.catalog.urlretrieve',
+        side_effect=fake_urlretrieve)
+
+    settings.CATALOG_CACHE_BASE_DIR = cachedir.strpath
+    settings.CATALOG_KIWIX_INSTALL_DIR = installdir.strpath
+
+    c = Catalog()
+    c.add_remote(
+        'foo', 'Content from Foo',
+        'file://{}'.format(remote_catalog_file.strpath))
+    c.update_cache()
+    c.install_packages(['wikipedia.tum'])
+
+    library = installdir.join('library.xml')
+    assert library.check(exists=True)
+
+    zim = installdir.join('data', 'content', 'wikipedia.tum.zim')
+    assert zim.check(file=True)
+
+    with library.open(mode='r') as f:
+        libdata = f.read()
+
+        assert 'path="data/content/wikipedia.tum.zim"' in libdata
+        assert 'indexPath="data/index/wikipedia.tum.zim.idx"' in libdata
+
+    # Now let's pretend a hacker modified the file
+    good_hash = sha256(zim.read_binary())
+    zim.write_text('你好嗎？', encoding='utf-8')
+
+    # And now, reinstall
+    c.reinstall_packages(['wikipedia.tum'])
+
+    assert sha256(zim.read_binary()).hexdigest() == good_hash.hexdigest()
+    assert zim.read_binary() != '你好嗎？'.encode('utf-8')
+
 def test_catalog_remove_package(tmpdir, settings, testdatadir, mocker):
     from ideascube.serveradmin.catalog import Catalog
 


### PR DESCRIPTION
Eventually, we're going to a place where we backup the list of installed content, but not the actual installed content.

Thus, when restoring from a backup, we will need a way to reinstall the content that the catalog thinks is installed.

More generally, this could also be useful if for some reason a package had been badly installed.