### PR TITLE
Do not fail if we try to add the same remote twice. (fix #357)

### DIFF
--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -48,6 +48,12 @@ class NoSuchPackage(Exception):
 class InvalidHandlerType(Exception):
     pass
 
+class ExistingRemoteError(Exception):
+    def __init__(self, remote):
+        self.remote = remote
+
+    def __str__(self):
+        return "Remote {} already exists".format(self.remote.id)
 
 class Remote:
     def __init__(self, id, name, url):
@@ -611,8 +617,9 @@ class Catalog:
         return sorted(self._remotes.values(), key=attrgetter('id'))
 
     def add_remote(self, id, name, url):
-        if id in self._remotes:
-            raise ValueError('There already is a "{}" remote'.format(id))
+        existing_remote = self._remotes.get(id)
+        if existing_remote:
+            raise ExistingRemoteError(existing_remote)
 
         r = Remote(id, name, url)
         r.to_file(os.path.join(self._cache_remote_dir, '{}.yml'.format(id)))

--- a/ideascube/serveradmin/tests/test_catalog.py
+++ b/ideascube/serveradmin/tests/test_catalog.py
@@ -579,7 +579,7 @@ def test_catalog_existing_remote(tmpdir, settings):
 
 
 def test_catalog_add_remotes(tmpdir, settings):
-    from ideascube.serveradmin.catalog import Catalog
+    from ideascube.serveradmin.catalog import Catalog, ExistingRemoteError
 
     settings.CATALOG_CACHE_BASE_DIR = tmpdir.strpath
     c = Catalog()
@@ -606,7 +606,7 @@ def test_catalog_add_remotes(tmpdir, settings):
     assert remote.name == 'Content provided by Foo'
     assert remote.url == 'http://foo.fr/catalog.yml'
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ExistingRemoteError) as exc:
         c.add_remote('foo', 'Content by Foo', 'http://foo.fr/catalog.yml')
 
     assert 'foo' in exc.exconly()

--- a/ideascube/serveradmin/tests/test_catalog_command.py
+++ b/ideascube/serveradmin/tests/test_catalog_command.py
@@ -90,10 +90,16 @@ def test_cannot_add_duplicate_remote(tmpdir, settings, monkeypatch):
 
     old_mtime = tmpdir.join('remotes', 'foo.yml').mtime()
 
+    # Adding the same remote with the same url should not fail.
+    call_command(
+        'catalog', 'remotes', 'add', remote['id'], remote['name'],
+        remote['url'])
+
+    # But should fail with different urls.
     with pytest.raises(CommandError):
         call_command(
             'catalog', 'remotes', 'add', remote['id'], remote['name'],
-            remote['url'])
+            remote['url'] + "bad")
 
     assert tmpdir.join('remotes', 'foo.yml').mtime() == old_mtime
 


### PR DESCRIPTION
If we try to add a remote already existing (same id) with same url,
print a warning.

If we try to add a remote already exsting but with different url,
raise as usual.