### PR TITLE
Order content by modified_at desc on blog index page (fix #368)

### DIFF
--- a/ideascube/blog/views.py
+++ b/ideascube/blog/views.py
@@ -9,7 +9,7 @@ from .models import Content
 
 class Index(FilterableViewMixin, ListView):
     model = Content
-    queryset = Content.objects.published()
+    queryset = Content.objects.published().order_by('-modified_at')
     template_name = 'blog/index.html'
     paginate_by = 10
 


### PR DESCRIPTION
Fix #368 