### PR TITLE
Add "order by" selector in list views (fix #363 fix #368)

### DIFF
--- a/ideascube/blog/templates/blog/index.html
+++ b/ideascube/blog/templates/blog/index.html
@@ -20,6 +20,7 @@
     {% url 'blog:index' as index %}
     {% include 'search/filter_cloud.html' %}
     {% include 'search/box.html' with action=index %}
+    {% include 'search/order_by.html' %}
     {% include 'search/filter_by_lang.html' %}
     {% tag_cloud url="blog:index" model=view.model tags=available_tags %}
 {% endblock third %}

--- a/ideascube/blog/tests/test_views.py
+++ b/ideascube/blog/tests/test_views.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 
@@ -37,6 +37,34 @@ def test_index_page_is_paginated(app, monkeypatch):
     assert not response.pyquery.find('.next')
     assert response.pyquery.find('.previous')
     response = app.get(reverse('blog:index') + '?page=3', status=404)
+
+
+def test_content_are_ordered_by_last_published_by_default(app):
+    content3 = ContentFactory(status=Content.PUBLISHED,
+                              published_at=datetime(2016, 6, 26, 16, 15))
+    content1 = ContentFactory(status=Content.PUBLISHED,
+                              published_at=datetime(2016, 6, 26, 16, 17))
+    content2 = ContentFactory(status=Content.PUBLISHED,
+                              published_at=datetime(2016, 6, 26, 16, 16))
+    response = app.get(reverse('blog:index'))
+    titles = response.pyquery.find('.card.blog h3')
+    assert titles[0].text == content1.title
+    assert titles[1].text == content2.title
+    assert titles[2].text == content3.title
+
+
+def test_should_take_sort_parameter_into_account(app):
+    content3 = ContentFactory(status=Content.PUBLISHED,
+                              published_at=datetime(2016, 6, 26, 16, 15))
+    content1 = ContentFactory(status=Content.PUBLISHED,
+                              published_at=datetime(2016, 6, 26, 16, 17))
+    content2 = ContentFactory(status=Content.PUBLISHED,
+                              published_at=datetime(2016, 6, 26, 16, 16))
+    response = app.get(reverse('blog:index'), {'sort': 'asc'})
+    titles = response.pyquery.find('.card.blog h3')
+    assert titles[0].text == content3.title
+    assert titles[1].text == content2.title
+    assert titles[2].text == content1.title
 
 
 def test_everyone_should_access_published_content(app, published):

--- a/ideascube/blog/views.py
+++ b/ideascube/blog/views.py
@@ -1,13 +1,25 @@
 from django.views.generic import (ListView, DetailView, UpdateView, CreateView)
+from django.db.models import F
+from django.utils.translation import ugettext_lazy as _
 
-from ideascube.mixins import FilterableViewMixin
+from ideascube.mixins import FilterableViewMixin, OrderableViewMixin
 from ideascube.decorators import staff_member_required
 
 from .forms import ContentForm
 from .models import Content
 
 
-class Index(FilterableViewMixin, ListView):
+class Index(FilterableViewMixin, OrderableViewMixin, ListView):
+
+    ORDERS = [
+        {
+            'key': 'published_at',
+            'label': _('Last published'),
+            'expression': F('published_at'),
+            'sort': 'desc'
+        }
+    ]
+
     model = Content
     queryset = Content.objects.published()
     template_name = 'blog/index.html'

--- a/ideascube/library/templates/library/index.html
+++ b/ideascube/library/templates/library/index.html
@@ -23,6 +23,7 @@
     {% url 'library:index' as index %}
     {% include 'search/filter_cloud.html' %}
     {% include 'search/box.html' with action=index %}
+    {% include 'search/order_by.html' %}
     {% include 'search/filter_by_lang.html' %}
     {% tag_cloud url="library:index" model=view.model tags=available_tags %}
 {% endblock third %}

--- a/ideascube/mediacenter/templates/mediacenter/index.html
+++ b/ideascube/mediacenter/templates/mediacenter/index.html
@@ -23,6 +23,7 @@
     {% url 'mediacenter:index' as index %}
     {% include 'search/filter_cloud.html' %}
     {% include 'search/box.html' with action=index %}
+    {% include 'search/order_by.html' %}
     {% include 'search/filter_by_kind.html' %}
     {% include 'search/filter_by_lang.html' %}
     {% tag_cloud url='mediacenter:index' model=view.model tags=available_tags %}

--- a/ideascube/mediacenter/views.py
+++ b/ideascube/mediacenter/views.py
@@ -1,24 +1,42 @@
-from collections import Counter
 import json
 
 from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.urlresolvers import reverse_lazy, resolve, Resolver404
+from django.db.models import F
+from django.db.models.functions import Lower
 from django.http import Http404, HttpResponse
 from django.template import RequestContext
 from django.template.loader import render_to_string
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic import (CreateView, DeleteView, DetailView, ListView,
                                   UpdateView)
 
 from ideascube.decorators import staff_member_required
-from ideascube.mixins import FilterableViewMixin
+from ideascube.mixins import FilterableViewMixin, OrderableViewMixin
 
 from .models import Document
 from .forms import DocumentForm
 
 
-class Index(FilterableViewMixin, ListView):
+class Index(FilterableViewMixin, OrderableViewMixin, ListView):
+
+    ORDERS = [
+        {
+            'key': 'modified_at',
+            'label': _('Last modification'),
+            'expression': F('modified_at'),
+            'sort': 'desc'
+        },
+        {
+            'key': 'title',
+            'label': _('Title'),
+            'expression': Lower('title'),  # Case insensitive.
+            'sort': 'asc'
+        }
+    ]
+
     model = Document
     template_name = 'mediacenter/index.html'
     paginate_by = 24

--- a/ideascube/search/templates/search/order_by.html
+++ b/ideascube/search/templates/search/order_by.html
@@ -1,0 +1,17 @@
+{% load i18n ideascube_tags %}
+{% if view.ORDERS %}
+<div class="card tinted">
+    <h4>{% trans "Order by" %}</h4>
+    {% for order in view.ORDERS %}
+        {% if order_by == order.key %}
+            {% if sort == 'asc' %}
+                <a href="{% replace_qs order_by=order.key sort='desc' %}" class="flatlist active">{% fa 'arrow-up' %} {{ order.label }}</a>
+            {% else %}
+                <a href="{% replace_qs order_by=order.key sort='asc' %}" class="flatlist active">{% fa 'arrow-down' %} {{ order.label }}</a>
+            {% endif %}
+        {% else %}
+            <a href="{% replace_qs order_by=order.key sort=order.sort %}" class="flatlist">{{ order.label }}</a>
+        {% endif %}
+    {% endfor %}
+</div>
+{% endif %}


### PR DESCRIPTION
Fix #363 fix #368.

- adds a "order by" box in the mediacenter, blog and library pages, which shows the current ordering, and the other available
- when clicking on the active ordering, the sort is reversed
- the possibility to define for each home page which orders are possible, including the default sort for each one

Preview:
![screenshot from 2016-06-27 23-23-03](https://cloud.githubusercontent.com/assets/146023/16396255/234ef934-3cbe-11e6-8b0c-d908636d56d0.png)
