### PR TITLE
Drop support of creating zip backup.

### DIFF
--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -338,6 +338,6 @@ SERVICES = [
 
 
 SESSION_COOKIE_AGE = 60 * 60  # Members must be logged out after one hour
-BACKUP_FORMAT = 'zip'  # One of 'zip', 'tar', 'bztar', 'gztar'
+BACKUP_FORMAT = 'gztar'  # One of 'tar', 'bztar', 'gztar'
 CATALOG_CACHE_BASE_DIR = '/var/cache/ideascube/catalog'
 TAGGIT_CASE_INSENSITIVE = True

--- a/ideascube/serveradmin/management/commands/backup.py
+++ b/ideascube/serveradmin/management/commands/backup.py
@@ -21,15 +21,18 @@ class Command(BaseCommand):
                             '"add", "delete" or "restore" action.')
         parser.add_argument('--format', default=None,
                             help='Backup file format. Possible values: {}'
-                                 'Default: {}'.format(Backup.SUPPORTED_FORMATS,
+                                 'Default: {}'.format(Backup.SUPPORTED_FORMATS_AT_CREATION,
                                                       Backup.FORMAT))
 
     def handle(self, *args, **options):
         format = options['format']
-        if format and format not in Backup.SUPPORTED_FORMATS:
+        action = options['action']
+        supported_formats = (Backup.SUPPORTED_FORMATS_AT_CREATION
+                                if action == 'create'
+                                else Backup.SUPPORTED_FORMATS )
+        if format and format not in supported_formats:
             self.stderr.write('Unsupported format: {}'.format(format))
             sys.exit(1)
-        action = options['action']
         reference = options['reference']
         interactive = options.get('interactive')
         if action == 'list':
@@ -37,11 +40,11 @@ class Command(BaseCommand):
             for backup in Backup.list():
                 self.stdout.write(str(backup))
         elif action == 'create':
-            backup = Backup.create(format=options['format'])
+            backup = Backup.create(format=format)
             self.stdout.write('Succesfully created backup {}'.format(backup))
         elif action == 'add':
             if not reference:
-                self.stderr.write('Missing path to zip backup to add.')
+                self.stderr.write('Missing path to archive backup to add.')
                 sys.exit(1)
             if not os.path.exists(reference):
                 self.stderr.write('File not found {}'.format(reference))

--- a/ideascube/serveradmin/tests/conftest.py
+++ b/ideascube/serveradmin/tests/conftest.py
@@ -9,4 +9,4 @@ DATA_ROOT = 'ideascube/serveradmin/tests/data/backup'
 def backup(monkeypatch):
     monkeypatch.setattr('ideascube.serveradmin.backup.Backup.ROOT', DATA_ROOT)
     # ZIP file should be shipped by git in serveradmin/tests/data
-    return Backup('musasa-0.1.0-201501241620.zip')
+    return Backup('musasa-0.1.0-201501241620.tar.gz')


### PR DESCRIPTION
Zip format is generally a pain to deal with (hello non-ascii characters).

In addition, we're about to add filtering of which files to backup and which files to ignore, which is trivial to do with the tarfile module, but much harder with the zipfile one.

To keep things simpler, we've decided to remove Zip support.

Zip backups are still supported for restore, though.

[CONFIG_CHANGE]
- zip is no more supported for BACKUP_FORMAT.
- Default value for BACKUP_FORMAT as change from 'zip' to 'gztar'

This is part of #342 