### PR TITLE
Use the document's kind instead of 'Document' for the Download buton

### DIFF
--- a/ideascube/mediacenter/templates/mediacenter/document_detail.html
+++ b/ideascube/mediacenter/templates/mediacenter/document_detail.html
@@ -14,7 +14,10 @@
     {% endif %}
     <div class="text">{{ document.summary }}</div>
     <div>
-        <a class="button" href="{{ document.original.url }}"><span class="fa fa-download fa-fw"></span> {% trans 'Download document' %}</a>
+        <a class="button" href="{{ document.original.url }}"><span class="fa fa-download fa-fw"></span>
+            {% blocktrans with kind=document.KIND_DICT|getitem:document.kind %}
+                Download {{ kind }}
+            {% endblocktrans %}</a>
     </div>
 {% endblock twothird %}
 {% block third %}


### PR DESCRIPTION
Fix #399.