### PR TITLE
Test all the config files

### DIFF
--- a/ideascube/conf/idb_eth_melkadida.py
+++ b/ideascube/conf/idb_eth_melkadida.py
@@ -1,4 +1,4 @@
 """Melkadida box in Ethiopia"""
-from idb_eth_bokolmanyo import *  # noqa
+from .idb_eth_bokolmanyo import *  # noqa
 
 IDEASCUBE_NAME = u"Melkadida"

--- a/ideascube/tests/test_settings.py
+++ b/ideascube/tests/test_settings.py
@@ -1,0 +1,23 @@
+import importlib
+
+import pytest
+
+
+def test_all_settings(request):
+    confdir = request.fspath.dirpath().dirpath().join('conf')
+    assert confdir.check(dir=True)
+
+    for path in confdir.listdir():
+        if path.ext != 'py':
+            continue
+
+        module = path.purebasename
+        module = '.conf.%s' % module
+
+        try:
+            importlib.import_module(module, package="ideascube")
+
+        except Exception as e:
+            print(path)
+            print(module)
+            pytest.fail(str(e))


### PR DESCRIPTION
We regularly make little syntax errors in the config files, leading to lots of pain down the road.

With this test, config files will be validated at each push to the ideascube repository, which should make us happier.

And in fact, it actually found a broken config!

That config is old, and probably worked at the times of Python 2, but we moved to Python 3 since then. Good thing that box was never updated. :-/

Fixes #395