### PR TITLE
Add a system user

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,12 @@ def staffuser():
     return UserFactory(short_name="Hello", password='password', is_staff=True)
 
 
+@pytest.fixture()
+def systemuser():
+    # Create it the same way the migration does it
+    return UserFactory(serial='__system__', full_name='System', password='!!')
+
+
 @pytest.fixture
 def setup_dirs(monkeypatch, tmpdir, settings):
     storage_root = tmpdir.mkdir('storage')

--- a/ideascube/migrations/0009_add_a_system_user.py
+++ b/ideascube/migrations/0009_add_a_system_user.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib.auth import get_user_model
+from django.db import migrations
+
+
+def add_user(*args):
+    User = get_user_model()
+    User(serial='__system__', full_name='System', password='!!').save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ideascube', '0008_user_sdb_level'),
+        ('search', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_user, None),
+    ]

--- a/ideascube/tests/test_models.py
+++ b/ideascube/tests/test_models.py
@@ -37,6 +37,18 @@ def test_create_superuser():
     assert user.is_staff
 
 
+def test_list_users():
+    model = get_user_model()
+    model.objects.create_user('123456')
+    model.objects.create_user('__system__')
+
+    users = model.objects.all()
+    assert [u.serial for u in users] == ['123456']
+
+    users = model.objects.all(include_system_user=True)
+    assert [u.serial for u in users] == ['__system__', '123456']
+
+
 def test_client_login(client, user):
     assert client.login(serial=user.serial, password='password')
 

--- a/ideascube/tests/test_views.py
+++ b/ideascube/tests/test_views.py
@@ -150,6 +150,11 @@ def test_user_list_page_should_be_accessible_to_staff(staffapp, user):
     response.mustcontain(str(user))
 
 
+def test_system_user_does_not_appear_in_list(staffapp, systemuser):
+    response = staffapp.get(reverse('user_list'), status=200)
+    response.mustcontain(no=str(systemuser))
+
+
 def test_user_list_page_is_paginated(staffapp, monkeypatch):
     monkeypatch.setattr(UserList, 'paginate_by', 2)
     UserFactory.create_batch(size=3)  # There is also the staff user.
@@ -173,6 +178,11 @@ def test_user_list_page_should_be_searchable(staffapp):
     response.mustcontain(str(user1), no=str(user2))
 
 
+def test_system_user_is_not_searchable(staffapp, systemuser):
+    response = staffapp.get(reverse('user_list') + '?q=system')
+    response.mustcontain(no=str(systemuser))
+
+
 def test_user_detail_page_should_not_be_accessible_to_anonymous(app, user):
     assert app.get(reverse('user_detail', kwargs={'pk': user.pk}),
                    status=302)
@@ -186,6 +196,11 @@ def test_non_staff_should_not_access_user_detail_page(loggedapp, user):
 def test_user_detail_page_should_be_accessible_to_staff(staffapp, user):
     response = staffapp.get(reverse('user_detail', kwargs={'pk': user.pk}))
     response.mustcontain(str(user))
+
+
+def test_system_user_cannot_be_viewed(staffapp, systemuser):
+    response = staffapp.get(
+        reverse('user_detail', kwargs={'pk': systemuser.pk}), status=404)
 
 
 def test_user_create_page_should_not_be_accessible_to_anonymous(app):
@@ -215,6 +230,13 @@ def test_should_not_create_user_without_serial(staffapp):
     form = staffapp.get(reverse('user_create')).forms['model_form']
     form.submit()
     assert len(user_model.objects.all()) == 1
+
+
+def test_system_serial_is_unique(staffapp, systemuser):
+    form = staffapp.get(reverse('user_create')).forms['model_form']
+    form['serial'] = systemuser.serial
+    response = form.submit()
+    assert response.status_code == 200
 
 
 def test_user_update_page_should_not_be_accessible_to_anonymous(app, user):
@@ -253,6 +275,11 @@ def test_should_not_update_user_without_serial(app, staffapp, user):
     assert dbuser.short_name == user.short_name
 
 
+def test_system_user_cannot_be_updated(staffapp, systemuser):
+    url = reverse('user_update', kwargs={'pk': systemuser.pk})
+    form = staffapp.get(url, status=404)
+
+
 def test_delete_page_should_not_be_reachable_to_anonymous(app, user):
     assert app.get(reverse('user_delete', kwargs={'pk': user.pk}), status=302)
 
@@ -288,6 +315,12 @@ def test_staff_user_can_delete_user(staffapp, user):
     form = staffapp.get(url).forms['delete_form']
     form.submit()
     assert len(user_model.objects.all()) == 1
+
+
+def test_system_user_cannot_be_deleted(staffapp, systemuser):
+    staffapp.get(
+        reverse('user_delete', kwargs={'pk': systemuser.pk}),
+        status=404)
 
 
 def test_anonymous_cannot_access_toggle_staff_page(app, user):
@@ -343,6 +376,12 @@ def test_staff_can_set_password(staffapp, client, user):
     form['new_password2'] = password
     form.submit().follow()
     assert user_model.objects.get(pk=user.pk).password != old_password
+
+
+def test_systemuser_cannot_have_its_password_changed(staffapp, systemuser):
+    staffapp.get(
+        reverse('user_set_password', kwargs={'pk': systemuser.pk}),
+        status=404)
 
 
 def test_anonymous_cannot_export_users(app, user):

--- a/ideascube/tests/test_views.py
+++ b/ideascube/tests/test_views.py
@@ -116,6 +116,16 @@ def test_login_page_should_not_log_in_user_with_incorrect_POST(client, user):
     assert not response.context['user'].is_authenticated()
 
 
+def test_system_user_cannot_log_in(client, systemuser):
+    response = client.post(reverse('login'), {
+        'username': systemuser.serial,
+        'password': systemuser.password,
+    }, follow=True)
+    assert response.status_code == 200
+    assert len(response.redirect_chain) == 0
+    assert not response.context['user'].is_authenticated()
+
+
 def test_login_from_link_should_redirect_to_previous(app, user, staffuser):
     # Loading staffuser fixture so we don't fail into welcome_staff page.
     mediacenter = app.get(reverse('mediacenter:index'))


### PR DESCRIPTION
This user won't be allowed to log in, so it won't be used by any physical person behind their screen.

However, it will be useful to change in-db settings in migrations or in a command-line too, since Setting instances require an actor.

It is a hidden user, to be used exclusively by Ideascube itself.
