### PR TITLE
Correctly catch output from logging to stderr.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,12 @@ from django.core.urlresolvers import reverse
 from ideascube.tests.factories import UserFactory
 from ideascube.search.utils import create_index_table
 
+import logging
+# This Handler always use sys.stderr and do not cache it.
+# Let's configure logging to always use it when we are testing.
+_alwaysUseStdErrHandler = logging._StderrHandler(logging.WARNING)
+logging.basicConfig(handlers=[_alwaysUseStdErrHandler])
+
 
 @pytest.fixture()
 def cleansearch():


### PR DESCRIPTION
The default Handler from logging store "in cache" the sys.stderr when it's
create.
When capsys from py.test try to mock sys.stderr, it is to late.

But logging has a Handler who always print to sys.stderr and do not cache
it.

We configure logging to use it, then, mocking from py.test works correctly.