### PR TITLE
Remove language skills from default USER_FORM_FIELDS

### DIFF
--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -227,7 +227,6 @@ USER_INDEX_FIELDS = ['short_name', 'full_name', 'serial']
 
 USER_FORM_FIELDS = (
     (_('Basic informations'), ['serial', 'short_name', 'full_name']),
-    (_('Language skills'), ['ar_level', 'en_level']),
 )
 
 ENTRY_ACTIVITY_CHOICES = [

--- a/ideascube/tests/test_models.py
+++ b/ideascube/tests/test_models.py
@@ -53,7 +53,9 @@ def test_client_login(client, user):
     assert client.login(serial=user.serial, password='password')
 
 
-def test_user_data_fields_should_return_labels_and_values():
+def test_user_data_fields_should_return_labels_and_values(settings):
+    settings.USER_DATA_FIELDS = ['short_name', 'ar_level']
+
     user = User(short_name='my name', ar_level=['u', 's'])
     fields = user.data_fields
     assert 'is_staff' not in fields


### PR DESCRIPTION
IDB are overwritting this config anyway, and we don't want them
for Koombooks.