### PR TITLE
Move back to the latest upstream release of resumable-urlretrieve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,8 @@ progressist
 pymarc==3.1.5
 python-networkmanager==1.1
 PyYAML==3.11
+resumable-urlretrieve==0.1.2
 Unidecode==0.4.19
-
-# See https://github.com/berdario/resumable-urlretrieve/pull/1
-git+https://github.com/ideascube/resumable-urlretrieve@chunk-sha
 
 # Upstream dbus-python is not pip-installable:
 #     https://bugs.freedesktop.org/show_bug.cgi?id=55439


### PR DESCRIPTION
We don't need to point ot our fork, now.

The reason we needed it went away as upstream merged out pull request:

berdario/resumable-urlretrieve#1