### PR TITLE
Aggressively cache the static files

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -122,3 +122,8 @@ def pytest_configure(config):
     #
     # Somehow the default database is always in memory, though.
     settings.DATABASES['transient']['TEST_NAME'] = ':memory:'
+
+    # The documentation says not to use the ManifestStaticFilesStorage for
+    # tests, and indeed if we do they fail.
+    settings.STATICFILES_STORAGE = (
+        'django.contrib.staticfiles.storage.StaticFilesStorage')

--- a/extras/nginx/ideascube
+++ b/extras/nginx/ideascube
@@ -25,6 +25,7 @@ server {
 
     location /static/ {
         alias /var/ideascube/static/;
+        expires 1y;
     }
 
     # Finally, send all non-media requests to the Django server.

--- a/ideascube/blog/templates/blog/content_form.html
+++ b/ideascube/blog/templates/blog/content_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n static ideascube_tags %}
+{% load i18n ideascube_tags %}
 
 {% block extra_head %}
     {% include 'ideascube/includes/form_statics.html' %}

--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -196,6 +196,7 @@ LOCALE_PATHS = (
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
 STATIC_URL = '/static/'
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 MEDIA_URL = '/media/'
 
 

--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -77,6 +77,7 @@ TEMPLATES = [
                 "django.core.context_processors.static",
                 "django.core.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
+                "ideascube.context_processors.favicon_url",
                 "ideascube.context_processors.server",
                 "ideascube.context_processors.settings",
                 "ideascube.context_processors.version",

--- a/ideascube/context_processors.py
+++ b/ideascube/context_processors.py
@@ -4,6 +4,11 @@ from ideascube import __version__
 from ideascube.configuration import get_config
 
 
+def favicon_url(request):
+    box_type = djsettings.IDEASCUBE_BOX_TYPE
+    return {'favicon_url': 'ideascube/img/favicons/%s.png' % box_type}
+
+
 def server(request):
     return {'server_name': get_config('server', 'site-name')}
 

--- a/ideascube/library/templates/library/book_card.html
+++ b/ideascube/library/templates/library/book_card.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static from staticfiles %}
 <div class="card">
     <a href="{% url 'library:book_detail' pk=book.pk %}">
         <h3>{{ book }}</h3>

--- a/ideascube/mediacenter/templates/mediacenter/document_card.html
+++ b/ideascube/mediacenter/templates/mediacenter/document_card.html
@@ -1,4 +1,4 @@
-{% load static ideascube_tags mediacenter_tags %}
+{% load ideascube_tags mediacenter_tags %}
 
 <div class="card">
     <a href="{{ document.get_absolute_url }}">

--- a/ideascube/mediacenter/templates/mediacenter/document_detail.html
+++ b/ideascube/mediacenter/templates/mediacenter/document_detail.html
@@ -1,6 +1,6 @@
 {% extends 'two-third-third.html' %}
 
-{% load i18n static ideascube_tags mediacenter_tags %}
+{% load i18n ideascube_tags mediacenter_tags %}
 
 {% block twothird %}
     <h5><a href="{% url 'mediacenter:index' %}">&lt; {% trans 'View all medias' %}</a></h5>

--- a/ideascube/mediacenter/templates/mediacenter/oembed.html
+++ b/ideascube/mediacenter/templates/mediacenter/oembed.html
@@ -1,4 +1,4 @@
-{% load static i18n mediacenter_tags %}
+{% load i18n mediacenter_tags %}
 {% if document.kind == document.IMAGE %}
     <img src="{{ document.original.url }}" />
     <p>{{ document.summary }} - {{ document.credits }}</p>

--- a/ideascube/templates/base.html
+++ b/ideascube/templates/base.html
@@ -1,4 +1,6 @@
-{% load static i18n %}
+{% load i18n %}
+{% load static from staticfiles %}
+
 <!DOCTYPE html>
 <html{% if LANGUAGE_CODE|language_bidi %} dir="rtl"{% endif %}>
     <head>

--- a/ideascube/templates/base.html
+++ b/ideascube/templates/base.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
         <title>{% block title %}{{ server_name }}{% endblock %}</title>
-        <link rel="icon" href="{% get_static_prefix %}ideascube/img/favicons/{{ IDEASCUBE_BOX_TYPE }}.png">
+        <link rel="icon" href="{% static favicon_url %}">
         <link rel="stylesheet" href="{% static 'ideascube/vendor/minislate/minislate.min.css' %}" />
         <link rel="stylesheet" href="{% static 'ideascube/vendor/font-awesome/css/font-awesome.min.css' %}" />
         <link rel="stylesheet" type="text/css" href="{% static "ideascube/main.css" %}">

--- a/ideascube/templates/ideascube/includes/footer.html
+++ b/ideascube/templates/ideascube/includes/footer.html
@@ -1,5 +1,5 @@
 {% load i18n ideascube_tags %}
-{% load static i18n %}
+{% load static from staticfiles %}
 
 {% spaceless %}
 <footer>

--- a/ideascube/templates/ideascube/includes/form_statics.html
+++ b/ideascube/templates/ideascube/includes/form_statics.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static from staticfiles %}
 
 <link rel="stylesheet" href="{% static 'ideascube/vendor/minislate/minislate.min.css' %}" />
 <link rel="stylesheet" href="{% static 'ideascube/vendor/pikaday/pikaday.css' %}" />


### PR DESCRIPTION
This moves us towards using Django's `ManifestStaticFilesStorage` which appends to the file names their hash, when running `collectstatic`, and then makes sure the requested URLs are to the URLs containing the hashes.

Once that's done, we can configure nginx to tell clients to keep these files in cache forever.

Fixes #467 