### PR TITLE
Fix the blog content form

### DIFF
--- a/ideascube/blog/forms.py
+++ b/ideascube/blog/forms.py
@@ -6,6 +6,7 @@ from .models import Content
 
 
 class ContentForm(forms.ModelForm):
+    use_required_attribute = False
 
     class Meta:
         model = Content


### PR DESCRIPTION
Everybody is sleeping here, but I can't, because my brain is fixating on this media URL thing from #468.

And while working on the media, I found this fallout from the Django 1.10 upgrade.

The commit message has all the details about the problems, so let me paste it here:

```
Fix the blog content form

The form plays a trick on the 'text' field: it hides it, and creates a
nicer-looking 'content' field. When submitting the form, the content of
the 'content' field is injected into the 'text' field.

This works great, until Django 1.10.

With Django 1.10, the browser refuses to submit the form, saying the
'text' field is empty and required.

This is due to this hidden gem from the Django 1.10 release notes:

> * Required form fields now have the required HTML attribute. Set the
>   Form.use_required_attribute attribute to False to disable it. You
>   could also add the novalidate attribute to <form> if you don’t want
>   browser validation.

https://docs.djangoproject.com/en/1.10/releases/1.10/#miscellaneous

This commit fixes the blog content form, which is the only one I found
problematic so far.

Hopefully it is the only one that is actually impacted. :-/
```

I'm not convinced this is the right fix to be honest. Plus there might be other forms impacted by this change.

But it allowed me to continue working on my media branch, and I figured opening a pull request was a good way to start a conversation about what that proper fix would be.