### PR TITLE
Force the re-creation of the index table when we make migration.

### DIFF
--- a/ideascube/search/apps.py
+++ b/ideascube/search/apps.py
@@ -6,7 +6,7 @@ from .utils import reindex_content
 
 def create_index(sender, **kwargs):
     if isinstance(sender, SearchConfig):
-        reindex_content(force=False)
+        reindex_content(force=True)
 
 
 class SearchConfig(AppConfig):


### PR DESCRIPTION
The structure of the index table may change and the migrate command
should handle those changes.

As the index table is not managed, we cannot detect those changes and
we must recreate the table all the time to be sure we've got the last
structure version.