### PR TITLE
search: Recreate the index table before migrating

### DIFF
--- a/ideascube/search/apps.py
+++ b/ideascube/search/apps.py
@@ -1,7 +1,12 @@
 from django.apps import AppConfig
-from django.db.models.signals import post_migrate
+from django.db.models.signals import pre_migrate, post_migrate
 
-from .utils import reindex_content
+from .utils import create_index_table, reindex_content
+
+
+def create_index(sender, **kwargs):
+    if isinstance(sender, SearchConfig):
+        create_index_table(force=True)
 
 
 def reindex(sender, **kwargs):
@@ -14,4 +19,5 @@ class SearchConfig(AppConfig):
     verbose_name = 'Search'
 
     def ready(self):
+        pre_migrate.connect(create_index, sender=self)
         post_migrate.connect(reindex, sender=self)

--- a/ideascube/search/apps.py
+++ b/ideascube/search/apps.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_migrate
 from .utils import reindex_content
 
 
-def create_index(sender, **kwargs):
+def reindex(sender, **kwargs):
     if isinstance(sender, SearchConfig):
         reindex_content(force=False)
 
@@ -14,4 +14,4 @@ class SearchConfig(AppConfig):
     verbose_name = 'Search'
 
     def ready(self):
-        post_migrate.connect(create_index, sender=self)
+        post_migrate.connect(reindex, sender=self)


### PR DESCRIPTION
We have two problems with the search app currently.

The first is that if an instance of ideascube gets updated from a very old version, the migrations fail. (#456)

The second is that because the Search model is not managed by Django, if we add new fields to it then no migration gets created, which breaks the application as well as the post-migrate reindex. (#489)

The solution to both is actually quite simple: simply always drop and recreate the index table before running the migrations.

Fixes #456
Fixes #489