### PR TITLE
We already use the static tag in the templates

### DIFF
--- a/ideascube/mediacenter/templatetags/mediacenter_tags.py
+++ b/ideascube/mediacenter/templatetags/mediacenter_tags.py
@@ -1,9 +1,8 @@
 from django import template
-from django.contrib.staticfiles.templatetags.staticfiles import static
 
 register = template.Library()
 
 
 @register.filter
 def default_preview_url(inst):
-    return static('mediacenter/default_{}.png'.format(inst.kind))
+    return 'mediacenter/default_{}.png'.format(inst.kind)


### PR DESCRIPTION
I introduced this error in 8c536774cfe40783350f6f569eb6580e79499600.

Fixes #492