### PR TITLE
improved form ergonomy (field focus and content editing)

### DIFF
--- a/ideascube/blog/templates/blog/content_form.html
+++ b/ideascube/blog/templates/blog/content_form.html
@@ -25,6 +25,7 @@
                 </div>
                 <div class="col two-third">
                     <h3>{% trans 'Content' %}</h3>
+                    <label class="strip required">Content</label>
                     <div data-editable-for="text" placeholder="{% trans 'Type your text here…' %}">{{ form.text.value|default:''|safe }}</div>
                 </div>
         </div>
@@ -32,6 +33,7 @@
 {% endblock content %}
 {% block extra_foot %}
     <script type="text/javascript">
+        ID.focusOn('[name=title]');
         ID.initEditor('text');
         ID.initDatepicker('published_at')
     </script>

--- a/ideascube/monitoring/templates/monitoring/loan.html
+++ b/ideascube/monitoring/templates/monitoring/loan.html
@@ -58,7 +58,7 @@
 
 {% block extra_foot %}
     <script type="text/javascript">
-        ID.focusOn('[name="barcode"]');
+        ID.focusOn('[name=specimen]');
         ID.initDatepicker('due_date');
         ID.initDatepicker('since');
         ID.stopEnterKey('specimen');

--- a/ideascube/serveradmin/templates/serveradmin/name.html
+++ b/ideascube/serveradmin/templates/serveradmin/name.html
@@ -10,3 +10,9 @@
     <input type="submit" value="{% trans 'Submit' %}" />
 </form>
 {% endblock %}
+
+{% block extra_foot %}
+    <script type="text/javascript">
+        ID.focusOn('[name=server_name]');
+    </script>
+{% endblock extra_foot %}

--- a/ideascube/static/ideascube/main.css
+++ b/ideascube/static/ideascube/main.css
@@ -206,7 +206,8 @@ html[dir='rtl'] .flow * + * {
 input[type="text"], input[type="password"], input[type="date"],
 input[type="datetime"], input[type="email"], input[type="number"],
 input[type="search"], input[type="tel"], input[type="time"],
-input[type="url"], textarea {
+input[type="url"], textarea,
+[contenteditable] {
     background-color: white;
     border: 1px solid #CCCCCC;
     border-radius: 2px 2px 2px 2px;
@@ -215,7 +216,7 @@ input[type="url"], textarea {
     display: block;
     font-family: inherit;
     font-size: 14px;
-    height: 50px;
+    min-height: 50px;
     margin: 0 0 14px;
     padding: 7px;
     width: 100%;

--- a/ideascube/templates/ideascube/user_form.html
+++ b/ideascube/templates/ideascube/user_form.html
@@ -25,6 +25,7 @@
 
 {% block extra_foot %}
     <script type="text/javascript">
+    ID.focusOn('[name=serial]')
         var inputs = document.querySelectorAll('#model_form input[type="text"]');
         for (var i = 0; i < inputs.length; i++) {
             if (ID.endswith(inputs[i].name, '_date')) ID.initDatepicker(inputs[i].name);


### PR DESCRIPTION
After a short training I noticed we could improve the form interface with little things:

- focus on first field by default. A user is typing when she sees the form without clicking for focus, she expects to be typing in the first box.
- it's nothing like obvious that the _content_ section is editable like other form fields when you are not used to transform readable text into editable text. Presenting a editable content as another form field may make it more obvious.

![screen shot 2016-09-29 at 2 31 55 pm](https://cloud.githubusercontent.com/assets/145172/18953241/16b8bae8-8656-11e6-9b61-f4ebc52fce87.png)
