### PR TITLE
catalog: Don't persist the cache when loading it

### DIFF
--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -801,8 +801,6 @@ class Catalog:
             if installed is not None:
                 self._installed = installed
 
-        self._persist_catalog()
-
         self._package_caches = [self._local_package_cache]
 
     def _persist_catalog(self):


### PR DESCRIPTION
We don't need to do that, since we use the cache from memory afterwards.
Plus, operations which modify the cache in-memory (install, remove,
clear cache, ...) will persist the cache on disk when they are done.

This means we can do less work, and it nicely fixes #496