### PR TITLE
home page allows clicking on labels to add the package

### DIFF
--- a/ideascube/serveradmin/templates/serveradmin/home_page.html
+++ b/ideascube/serveradmin/templates/serveradmin/home_page.html
@@ -9,8 +9,8 @@
         <tr><th>{% trans 'Card name' %}</th><th>{% trans 'Displayed' %}</th></tr>
         {% for package in installed_packages %}
         <tr>
-            <td>{{ package.name }}</td>
-            <td><input name="displayed" type="checkbox" value="{{ package.id }}" {% if package.id in displayed_packages %}checked{% endif %}/></td>
+            <td><label for="package-{{ package.id }}">{{ package.name }}</label></td>
+            <td><input id="package-{{ package.id }}" name="displayed" type="checkbox" value="{{ package.id }}" {% if package.id in displayed_packages %}checked{% endif %}/></td>
         </tr>
         {% endfor %}
     </table>

--- a/ideascube/static/ideascube/main.css
+++ b/ideascube/static/ideascube/main.css
@@ -990,6 +990,11 @@ html[dir='rtl'] .search input[type='submit'] {
     position: initial;
 }
 
+#cards td label {
+  display: block;
+  cursor: pointer;
+}
+
 /* ************************************************* */
 /* **************** MEDIAS CENTER ****************** */
 /* ************************************************* */


### PR DESCRIPTION
The "home page" configuration has now the possibility of clicking a label, not only the small checkbox, to add a package to the selection.

Fix #511 