### PR TITLE
fixed translation for language switching

### DIFF
--- a/ideascube/forms.py
+++ b/ideascube/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 class UserForm(forms.ModelForm):

--- a/ideascube/library/forms.py
+++ b/ideascube/library/forms.py
@@ -1,9 +1,8 @@
 import re
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import get_language, ugettext_lazy as _
 
 from ideascube.widgets import LangSelect
 
@@ -88,7 +87,7 @@ class ImportForm(forms.Form):
             if not notice:
                 continue
             notice.setdefault('section', Book.OTHER)
-            notice.setdefault('lang', settings.LANGUAGE_CODE)
+            notice.setdefault('lang', get_language())
             isbn = notice.get('isbn')
             instance = None
             if isbn:

--- a/ideascube/library/views.py
+++ b/ideascube/library/views.py
@@ -2,14 +2,13 @@ import os
 from io import BytesIO
 from zipfile import ZipFile
 
-from django.conf import settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse_lazy
 from django.db.models import F
 from django.db.models.functions import Lower
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import get_language, ugettext as _
 from django.views.generic import (CreateView, DeleteView, DetailView, FormView,
                                   ListView, UpdateView, View)
 
@@ -80,7 +79,7 @@ class BookCreate(CreateView):
     model = Book
     form_class = BookForm
     initial = {
-        'lang': settings.LANGUAGE_CODE
+        'lang': get_language()
     }
 book_create = staff_member_required(BookCreate.as_view())
 

--- a/ideascube/mediacenter/views.py
+++ b/ideascube/mediacenter/views.py
@@ -1,13 +1,11 @@
 from urllib.parse import urlparse
 
-from django.conf import settings
 from django.core.urlresolvers import reverse_lazy, resolve, Resolver404
 from django.db.models import F
 from django.db.models.functions import Lower
 from django.http import Http404, JsonResponse
-from django.template import RequestContext
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import get_language, ugettext_lazy as _
 from django.views.generic import (CreateView, DeleteView, DetailView, ListView,
                                   UpdateView)
 
@@ -92,7 +90,7 @@ class DocumentCreate(CreateView):
     model = Document
     form_class = DocumentForm
     initial = {
-        'lang': settings.LANGUAGE_CODE,
+        'lang': get_language(),
     }
 document_create = staff_member_required(DocumentCreate.as_view())
 

--- a/ideascube/monitoring/forms.py
+++ b/ideascube/monitoring/forms.py
@@ -4,7 +4,7 @@ from datetime import date
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .models import Entry, InventorySpecimen, Loan, Specimen
 

--- a/ideascube/monitoring/models.py
+++ b/ideascube/monitoring/models.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from ideascube.models import TimeStampedModel
 

--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -436,6 +436,8 @@ class ZippedMedias(SimpleZipPackage):
                 media_info))
 
         if 'lang' not in media_info:
+            # Unsure if we shouldn't use `get_language()` instead of
+            # LANGUAGE_CODE from the settings.
             media_info['lang'] = settings.LANGUAGE_CODE
 
         kind = media_info.get('kind')


### PR DESCRIPTION
swapped to `lazyloading` for modules that load translation on module import.
getting the language from django language processor instead of directly from the settings.