### PR TITLE
fixed space for titles in forms

### DIFF
--- a/ideascube/static/ideascube/main.css
+++ b/ideascube/static/ideascube/main.css
@@ -336,6 +336,9 @@ html[dir='rtl'] .show-password {
     margin-right: -25px;
 }
 
+form h3 {
+  margin-top: 1.8em;
+}
 
 
 /* ************************************************* */


### PR DESCRIPTION
Space between box and the next title was too narrow.

![screen shot 2016-10-04 at 11 01 52 pm](https://cloud.githubusercontent.com/assets/145172/19090391/d0634998-8a86-11e6-9bc0-0bc5871cb8df.png)
