### PR TITLE
Simplify the installation of static site packages

### DIFF
--- a/extras/nginx/ideascube
+++ b/extras/nginx/ideascube
@@ -35,3 +35,16 @@ server {
     }
 }
 
+# serve the static sites
+server {
+    listen 80;
+    listen [::]:80;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name sites.ideasbox.lan sites.ideasbox.local sites.koombook.lan sites.koombook.local;
+
+    charset utf-8;
+
+    root /var/ideascube/nginx/;
+}

--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -216,8 +216,6 @@ IDEASCUBE_BOX_TYPE = 'ideasbox'
 LOAN_DURATION = 0  # In days.
 
 DOMAIN = 'ideasbox.lan'
-WIKIPEDIA_URL = 'http://wikipedia.{domain}'.format(domain=DOMAIN)
-KHANACADEMY_URL = 'http://khanacademy.{domain}'.format(domain=DOMAIN)
 
 # Fields to be used in the entry export. This export is supposed to be
 # anonymized, so no personal data like name.

--- a/ideascube/serveradmin/tests/test_catalog.py
+++ b/ideascube/serveradmin/tests/test_catalog.py
@@ -526,7 +526,7 @@ def test_kiwix_commits_after_remove(settings, zippedzim_path, mocker):
     manager().restart.assert_not_called()
 
 
-def test_nginx_installs_zippedzim(settings, staticsite_path):
+def test_nginx_installs_staticsite(settings, staticsite_path):
     from ideascube.serveradmin.catalog import Nginx, StaticSite
 
     Nginx.root = os.path.join(settings.STORAGE_ROOT, 'nginx')
@@ -546,7 +546,7 @@ def test_nginx_installs_zippedzim(settings, staticsite_path):
         assert 'static content' in f.read()
 
 
-def test_nginx_removes_zippedzim(settings, staticsite_path):
+def test_nginx_removes_staticsite(settings, staticsite_path):
     from ideascube.serveradmin.catalog import Nginx, StaticSite
 
     Nginx.root = os.path.join(settings.STORAGE_ROOT, 'nginx')

--- a/ideascube/serveradmin/tests/test_catalog.py
+++ b/ideascube/serveradmin/tests/test_catalog.py
@@ -531,8 +531,7 @@ def test_nginx_installs_staticsite(settings, staticsite_path):
 
     Nginx.root = os.path.join(settings.STORAGE_ROOT, 'nginx')
 
-    p = StaticSite('w2eu', {
-        'url': 'https://foo.fr/w2eu-2016-02-26.zim'})
+    p = StaticSite('w2eu', {})
     h = Nginx()
     h.install(p, staticsite_path.strpath)
 
@@ -551,8 +550,7 @@ def test_nginx_removes_staticsite(settings, staticsite_path):
 
     Nginx.root = os.path.join(settings.STORAGE_ROOT, 'nginx')
 
-    p = StaticSite('w2eu', {
-        'url': 'https://foo.fr/w2eu-2016-02-26.zim'})
+    p = StaticSite('w2eu', {})
     h = Nginx()
     h.install(p, staticsite_path.strpath)
 
@@ -575,8 +573,7 @@ def test_nginx_commits_after_install(settings, staticsite_path, mocker):
 
     manager = mocker.patch('ideascube.serveradmin.catalog.SystemManager')
 
-    p = StaticSite('w2eu', {
-        'url': 'https://foo.fr/w2eu-2016-02-26.zim'})
+    p = StaticSite('w2eu', {})
     h = Nginx()
     h.install(p, staticsite_path.strpath)
     h.commit()
@@ -605,8 +602,7 @@ def test_nginx_commits_after_remove(settings, staticsite_path, mocker):
     manager = mocker.patch('ideascube.serveradmin.catalog.SystemManager')
     manager().get_service.side_effect = NoSuchUnit
 
-    p = StaticSite('w2eu', {
-        'url': 'https://foo.fr/w2eu-2016-02-26.zim'})
+    p = StaticSite('w2eu', {})
     h = Nginx()
     h.install(p, staticsite_path.strpath)
     h.commit()

--- a/ideascube/templates/ideascube/includes/cards/static-site.html
+++ b/ideascube/templates/ideascube/includes/cards/static-site.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="card tinted {{ card.css_class }}">
-    <a href="http://{{ card.package_id }}.{{ domain }}">
+    <a href="http://sites.{{ domain }}/{{ card.package_id }}">
         <h4><span class="theme {{ card.theme }}">{% trans card.theme %}</span><span>{{ card.name }}</span></h4>
         <p>{{ card.description }}</p>
     </a>

--- a/ideascube/views.py
+++ b/ideascube/views.py
@@ -39,6 +39,7 @@ from .mixins import CSVExportMixin
 
 user_model = get_user_model()
 
+
 def build_package_card_info():
     package_card_info = []
     catalog = catalog_mod.Catalog()
@@ -57,6 +58,7 @@ def build_package_card_info():
         }
         package_card_info.append(card_info)
     return package_card_info
+
 
 def index(request):
     if not user_model.objects.filter(is_staff=True).exists():


### PR DESCRIPTION
This moves us to having a single NGinx configuration file to handle all the static sites we install as packages.

I'm bundling with it a few minor changes I stumbled upon while working on this.

Fixes #431 