### PR TITLE
Hide the backup management

### DIFF
--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -278,14 +278,6 @@ STAFF_HOME_CARDS = [
     {
         'is_staff': True,
         'category': 'manage',
-        'url': 'server:backup',
-        'title': _('Backups'),
-        'description': _('Create, restore, download, upload backups.'),
-        'fa': 'life-ring',
-    },
-    {
-        'is_staff': True,
-        'category': 'manage',
         'url': 'server:wifi',
         'title': _('Wi-Fi'),
         'description': _('Manage Wi-Fi connections.'),

--- a/ideascube/conf/kb.py
+++ b/ideascube/conf/kb.py
@@ -7,7 +7,7 @@ BACKUP_FORMAT = 'gztar'
 IDEASCUBE_BOX_TYPE = 'koombook'
 STAFF_HOME_CARDS = [c for c in STAFF_HOME_CARDS
                     if c['url'] in ['user_list', 'server:power',
-                                    'server:backup', 'server:wifi']]
+                                    'server:wifi']]
 
 HOME_CARDS = STAFF_HOME_CARDS + [
     {

--- a/ideascube/serveradmin/templates/serveradmin/index.html
+++ b/ideascube/serveradmin/templates/serveradmin/index.html
@@ -20,7 +20,6 @@
             <li>{% fa 'language' 'fa-fw' %} <a href="{% url 'server:languages' %}">{% trans "Languages" %}</a></li>
             <li>{% fa 'cogs' 'fa-fw' %} <a href="{% url 'server:services' %}">{% trans "Manage services" %}</a></li>
             <li>{% fa 'power-off' 'fa-fw' %} <a href="{% url 'server:power' %}">{% trans "Restart server" %}</a></li>
-            <li>{% fa 'life-ring' 'fa-fw' %} <a href="{% url 'server:backup' %}">{% trans "Manage backups" %}</a></li>
             <li>{% fa 'plug' 'fa-fw' %} <a href="{% url 'server:battery' %}">{% trans "Monitor battery" %}</a></li>
             <li>{% fa 'wifi' 'fa-fw' %} <a href="{% url 'server:wifi' %}">{% trans "Manage Wi-Fi" %}</a></li>
             <li>{% fa 'th' 'fa-fw' %} <a href="{% url 'server:home_page' %}">{% trans "Manage home page" %}</a></li>


### PR DESCRIPTION
For now, this just brings in too much risk of filling up the disk and
bricking the box.

We can bring it back once we're confident we've made sufficient
improvements, either to the functionality itself, or to the disk
capacity.

Fixes #524