### PR TITLE
Use timezone-aware datetime objects

### DIFF
--- a/ideascube/blog/tests/conftest.py
+++ b/ideascube/blog/tests/conftest.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -13,7 +13,7 @@ def published():
 
 @pytest.fixture()
 def published_in_the_future():
-    publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=10)
+    publication_date = datetime.now(timezone.utc) + timedelta(days=10)
     return ContentFactory(status=Content.PUBLISHED,
                           published_at=publication_date)
 

--- a/ideascube/blog/tests/factories.py
+++ b/ideascube/blog/tests/factories.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 
 import factory
 
@@ -13,7 +13,7 @@ class ContentFactory(factory.django.DjangoModelFactory):
     text = "This is a test subtitle"
     author = factory.SubFactory(UserFactory)
     published_at = factory.LazyAttribute(
-        lambda o: datetime.datetime.utcnow() - datetime.timedelta(hours=1))
+        lambda o: datetime.now(timezone.utc) - timedelta(hours=1))
     image = factory.django.ImageField()
 
     @factory.post_generation

--- a/ideascube/monitoring/tests/factories.py
+++ b/ideascube/monitoring/tests/factories.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 import factory
 from factory.fuzzy import FuzzyText
@@ -17,7 +17,7 @@ class EntryFactory(factory.django.DjangoModelFactory):
 
 
 class InventoryFactory(factory.django.DjangoModelFactory):
-    made_at = factory.LazyAttribute(lambda o: datetime.datetime.utcnow())
+    made_at = factory.LazyAttribute(lambda o: datetime.now(timezone.utc))
 
     class Meta:
         model = Inventory


### PR DESCRIPTION
Found this because `make dummydata` was emitting warnings.