### PR TITLE
Clean kb conf

### DIFF
--- a/ideascube/conf/kb.py
+++ b/ideascube/conf/kb.py
@@ -22,7 +22,4 @@ HOME_CARDS = STAFF_HOME_CARDS + [
     {
         'id': 'khanacademy',
     },
-    {
-        'id': 'software',
-    }
 ]

--- a/ideascube/conf/kb.py
+++ b/ideascube/conf/kb.py
@@ -17,9 +17,6 @@ HOME_CARDS = STAFF_HOME_CARDS + [
         'id': 'mediacenter',
     },
     {
-        'id': 'bsfcampus',
-    },
-    {
         'id': 'khanacademy',
     },
 ]

--- a/ideascube/conf/kb_bdi_tv5monde.py
+++ b/ideascube/conf/kb_bdi_tv5monde.py
@@ -1,17 +1,5 @@
 """KoomBook conf"""
 from .kb import *  # noqa
-from django.utils.translation import ugettext_lazy as _
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'TV5 Monde Burundi'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    }
-]

--- a/ideascube/conf/kb_bdi_tv5monde.py
+++ b/ideascube/conf/kb_bdi_tv5monde.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 from django.utils.translation import ugettext_lazy as _

--- a/ideascube/conf/kb_bsfcampus.py
+++ b/ideascube/conf/kb_bsfcampus.py
@@ -1,0 +1,7 @@
+from .kb import *  # noqa
+
+HOME_CARDS = HOME_CARDS + [
+    {
+        'id': 'bsfcampus',
+    },
+]

--- a/ideascube/conf/kb_bsfcampus_civ.py
+++ b/ideascube/conf/kb_bsfcampus_civ.py
@@ -1,5 +1,5 @@
 """KoomBook conf"""
-from .kb import *  # noqa
+from .kb_bsfcampus import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'BSF Campus CÔTE D’IVOIRE'

--- a/ideascube/conf/kb_bsfcampus_civ.py
+++ b/ideascube/conf/kb_bsfcampus_civ.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_bsfcampus_cmr.py
+++ b/ideascube/conf/kb_bsfcampus_cmr.py
@@ -1,5 +1,5 @@
 """KoomBook conf"""
-from .kb import *  # noqa
+from .kb_bsfcampus import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'BSF Campus CAMEROUN'

--- a/ideascube/conf/kb_bsfcampus_cmr.py
+++ b/ideascube/conf/kb_bsfcampus_cmr.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_bsfcampus_sen.py
+++ b/ideascube/conf/kb_bsfcampus_sen.py
@@ -1,5 +1,5 @@
 """KoomBook conf"""
-from .kb import *  # noqa
+from .kb_bsfcampus import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'BSF Campus SÉNÉGAL'

--- a/ideascube/conf/kb_bsfcampus_sen.py
+++ b/ideascube/conf/kb_bsfcampus_sen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_cdf_fra.py
+++ b/ideascube/conf/kb_cdf_fra.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_cdf_fra.py
+++ b/ideascube/conf/kb_cdf_fra.py
@@ -11,15 +11,6 @@ HOME_CARDS = STAFF_HOME_CARDS + [
         'id': 'mediacenter',
     },
     {
-        'id': 'wikipedia.old',
-    },
-    {
-        'id': 'vikidia.old',
-    },
-    {
         'id': 'appinventor',
-    },
-    {
-        'id': 'cpassorcier.old',
     },
 ]

--- a/ideascube/conf/kb_civ_babylab.py
+++ b/ideascube/conf/kb_civ_babylab.py
@@ -1,20 +1,5 @@
 """KoomBook conf"""
-from .kb import *  # noqa
-from django.utils.translation import ugettext_lazy as _
+from .kb_bsfcampus import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'BabyLab'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'bsfcampus',
-    },
-    {
-        'id': 'khanacademy',
-    }
-]

--- a/ideascube/conf/kb_civ_babylab.py
+++ b/ideascube/conf/kb_civ_babylab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 from django.utils.translation import ugettext_lazy as _

--- a/ideascube/conf/kb_esp_avanti.py
+++ b/ideascube/conf/kb_esp_avanti.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_esp_avanti.py
+++ b/ideascube/conf/kb_esp_avanti.py
@@ -2,14 +2,3 @@
 from .kb import *  # noqa
 
 LANGUAGE_CODE = 'es'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    },
-]

--- a/ideascube/conf/kb_eth_kytabu.py
+++ b/ideascube/conf/kb_eth_kytabu.py
@@ -3,14 +3,3 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'KYTABU'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    },
-]

--- a/ideascube/conf/kb_eth_kytabu.py
+++ b/ideascube/conf/kb_eth_kytabu.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_eth_kytabu.py
+++ b/ideascube/conf/kb_eth_kytabu.py
@@ -11,9 +11,6 @@ HOME_CARDS = STAFF_HOME_CARDS + [
         'id': 'mediacenter',
     },
     {
-        'id': 'gutenberg.old',
-    },
-    {
         'id': 'khanacademy',
     },
 ]

--- a/ideascube/conf/kb_gin_conakry.py
+++ b/ideascube/conf/kb_gin_conakry.py
@@ -1,23 +1,10 @@
 """KoomBook conf"""
-from .kb import *  # noqa
-from django.utils.translation import ugettext_lazy as _
+from .kb_bsfcampus import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'Conakry'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'bsfcampus',
-    },
+HOME_CARDS = HOME_CARDS + [
     {
         'id': 'koombookedu',
     },
-    {
-        'id': 'khanacademy',
-    }
 ]

--- a/ideascube/conf/kb_gin_conakry.py
+++ b/ideascube/conf/kb_gin_conakry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 from django.utils.translation import ugettext_lazy as _

--- a/ideascube/conf/kb_ifb_bdi.py
+++ b/ideascube/conf/kb_ifb_bdi.py
@@ -3,16 +3,7 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'Institut Français Burundi'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    },
+HOME_CARDS = HOME_CARDS + [
     {
         'id': 'appinventor',
     },

--- a/ideascube/conf/kb_ifb_bdi.py
+++ b/ideascube/conf/kb_ifb_bdi.py
@@ -11,18 +11,9 @@ HOME_CARDS = STAFF_HOME_CARDS + [
         'id': 'mediacenter',
     },
     {
-        'id': 'wikipedia.old',
-    },
-    {
         'id': 'khanacademy',
     },
     {
-        'id': 'vikidia.old',
-    },
-    {
         'id': 'appinventor',
-    },
-    {
-        'id': 'gutenberg.old',
     },
 ]

--- a/ideascube/conf/kb_ifb_bdi.py
+++ b/ideascube/conf/kb_ifb_bdi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_jor_croixrouge.py
+++ b/ideascube/conf/kb_jor_croixrouge.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_jor_croixrouge.py
+++ b/ideascube/conf/kb_jor_croixrouge.py
@@ -3,14 +3,3 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'ar'
 IDEASCUBE_NAME = 'Red Cross'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    }
-]

--- a/ideascube/conf/kb_mooc_cog.py
+++ b/ideascube/conf/kb_mooc_cog.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_mooc_cog.py
+++ b/ideascube/conf/kb_mooc_cog.py
@@ -7,7 +7,4 @@ HOME_CARDS = STAFF_HOME_CARDS + [
     {
         'id': 'koombookedu',
     },
-    {
-        'id': 'wikipedia.old',
-    },
 ]

--- a/ideascube/conf/kb_mooc_cog.py
+++ b/ideascube/conf/kb_mooc_cog.py
@@ -3,7 +3,7 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'UNIVERSITE RDC'
-HOME_CARDS = STAFF_HOME_CARDS + [
+HOME_CARDS = HOME_CARDS + [
     {
         'id': 'koombookedu',
     },

--- a/ideascube/conf/kb_nic_nicarali.py
+++ b/ideascube/conf/kb_nic_nicarali.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_nic_nicarali.py
+++ b/ideascube/conf/kb_nic_nicarali.py
@@ -3,14 +3,3 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'es'
 IDEASCUBE_NAME = 'Nicarali'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    },
-]

--- a/ideascube/conf/kb_rca_alliancefrancaise.py
+++ b/ideascube/conf/kb_rca_alliancefrancaise.py
@@ -3,6 +3,3 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'fr'
 IDEASCUBE_NAME = 'Alliance française de Bangui'
-
-# Disable BSF Campus for now
-HOME_CARDS = [card for card in HOME_CARDS if card.get('id') != 'bsfcampus']

--- a/ideascube/conf/kb_rca_alliancefrancaise.py
+++ b/ideascube/conf/kb_rca_alliancefrancaise.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_servir_ben.py
+++ b/ideascube/conf/kb_servir_ben.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_tza_ambassadeDeFrance.py
+++ b/ideascube/conf/kb_tza_ambassadeDeFrance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_tza_ambassadeDeFrance.py
+++ b/ideascube/conf/kb_tza_ambassadeDeFrance.py
@@ -3,14 +3,3 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'en'
 IDEASCUBE_NAME = 'Ambassade De France'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    }
-]

--- a/ideascube/conf/kb_usa_p2pu.py
+++ b/ideascube/conf/kb_usa_p2pu.py
@@ -3,14 +3,3 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'en'
 IDEASCUBE_NAME = 'P2PU KOOMBOOK'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    },
-]

--- a/ideascube/conf/kb_usa_p2pu.py
+++ b/ideascube/conf/kb_usa_p2pu.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 

--- a/ideascube/conf/kb_usa_wmapache.py
+++ b/ideascube/conf/kb_usa_wmapache.py
@@ -3,14 +3,3 @@ from .kb import *  # noqa
 
 LANGUAGE_CODE = 'en'
 IDEASCUBE_NAME = 'WHITE MOUNTAIN APACHE'
-HOME_CARDS = STAFF_HOME_CARDS + [
-    {
-        'id': 'blog',
-    },
-    {
-        'id': 'mediacenter',
-    },
-    {
-        'id': 'khanacademy',
-    },
-]

--- a/ideascube/conf/kb_usa_wmapache.py
+++ b/ideascube/conf/kb_usa_wmapache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """KoomBook conf"""
 from .kb import *  # noqa
 


### PR DESCRIPTION
This simplifies the KB confs.
The target is to use only generic confs (kb, kb_bsfcampus, maybe one or two more) as much as possible.
Some confs still remain because of the IDEASCUBE_NAME, that needs to be updated before (through Ansiblecube). That will be another step.
Plus, we may tackle in another thread the LANGUAGE_CODE (using the server lang?), for now we can proceed, as it's not used for the UI (only for scripts and such; on the UI we default on browser language).

@bochecha @mgautierfr one of you can have a quick safety look? I'd like to release tomorrow morning before going to work :)

Thankss!