### PR TITLE
Load user from migration registry when creating system user

### DIFF
--- a/ideascube/migrations/0009_add_a_system_user.py
+++ b/ideascube/migrations/0009_add_a_system_user.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.contrib.auth import get_user_model
 from django.db import migrations
 
 
-def add_user(*args):
-    User = get_user_model()
+def add_user(apps, *args):
+    User = apps.get_model('ideascube', 'User')
     User(serial='__system__', full_name='System', password='!!').save()
 
 


### PR DESCRIPTION
Always load models from the registry in migration files.
I hate the idea of touching a migration already released, but
this one prevents us from adding new properties to User.
If we load the User directly (not from registry) when creating
the user model, we'll try to create a user with column that does
not exist at the time of this migration.