### PR TITLE
Workaround the bad Koombook battery driver

### DIFF
--- a/ideascube/serveradmin/battery.py
+++ b/ideascube/serveradmin/battery.py
@@ -1,0 +1,11 @@
+import batinfo
+
+
+def get_batteries():
+    batteries = batinfo.batteries()
+
+    if batteries:
+        return batteries.stat
+
+    else:
+        return []

--- a/ideascube/serveradmin/battery.py
+++ b/ideascube/serveradmin/battery.py
@@ -1,11 +1,29 @@
 import batinfo
 
 
+class Lime2Battery(batinfo.Battery):
+    @property
+    def status(self):
+        if self.charging == 0:
+            return 'Discharging'
+
+        elif self.capacity < 100:
+            return 'Charging'
+
+        else:
+            return 'Full'
+
+
 def get_batteries():
     batteries = batinfo.batteries()
 
     if batteries:
         return batteries.stat
 
-    else:
+    try:
+        # We might be running on a Lime2 Koombook
+        # https://github.com/ideascube/ideascube/issues/446#issuecomment-244143565
+        return [Lime2Battery(path='/sys/power/axp_pmu', name='battery')]
+
+    except FileNotFoundError:
         return []

--- a/ideascube/serveradmin/templates/serveradmin/battery.html
+++ b/ideascube/serveradmin/templates/serveradmin/battery.html
@@ -4,7 +4,7 @@
 {% block twothird %}
 <h2>{% trans "Battery monitoring" %}</h2>
 <ul>
-{% for battery in batteries.stat %}
+{% for battery in batteries %}
 	<li><strong>{% trans 'Status' %}</strong> {{ battery.status }}</li>
 	<li><strong>{% trans 'Capacity' %}</strong> {{ battery.capacity|default:0|min:100 }}%</li>
 </ul>

--- a/ideascube/serveradmin/views.py
+++ b/ideascube/serveradmin/views.py
@@ -1,6 +1,5 @@
 from subprocess import call
 
-import batinfo
 from django.conf import settings
 from django.contrib import messages
 from django.http import StreamingHttpResponse
@@ -12,6 +11,7 @@ from ideascube.decorators import staff_member_required
 from ideascube.utils import get_all_languages
 
 from .backup import Backup
+from .battery import get_batteries
 from .systemd import Manager, NoSuchUnit, UnitManagementError
 from .wifi import (
     AvailableWifiNetwork, KnownWifiConnection, enable_wifi, WifiError)
@@ -166,7 +166,7 @@ def backup(request):
 @staff_member_required
 def battery(request):
     return render(request, 'serveradmin/battery.html',
-                  {'batteries': batinfo.batteries()})
+                  {'batteries': get_batteries()})
 
 
 @staff_member_required


### PR DESCRIPTION
This is pretty ugly, but the Koombook battery driver doesn't respect the
Linux convention for reporting the power status to sysfs.

As a result, batinfo doesn't work with it.

Since this is quite specific, I don't think it makes sense to push that
upstream to batinfo, so I opted for a workaround in our code.

Fixes #446