### PR TITLE
Better handle the library to stock migration

### DIFF
--- a/ideascube/library/migrations/0008_library_stock.py
+++ b/ideascube/library/migrations/0008_library_stock.py
@@ -163,7 +163,9 @@ class Migration(migrations.Migration):
             },
             bases=('monitoring.specimen', models.Model),
         ),
-        migrations.RunPython(migrate_data, hints={'using': 'default'}),
+        migrations.RunPython(
+            migrate_data, migrations.RunPython.noop,
+            hints={'using': 'default'}),
         migrations.DeleteModel('OldBookSpecimen'),
         migrations.DeleteModel('OldBook'),
     ]

--- a/ideascube/library/migrations/0008_library_stock.py
+++ b/ideascube/library/migrations/0008_library_stock.py
@@ -25,13 +25,13 @@ def migrate_data(apps, schema_editor):
             tags=old_book.tags)
         new_book.save()
 
-        for old_specimen in old_book.specimens.all():
-            new_specimen = BookSpecimen(
-                barcode=old_specimen.serial, item=new_book, count=1,
-                comments=old_specimen.remarks,
+        for old_bookspecimen in old_book.specimens.all():
+            new_bookspecimen = BookSpecimen(
+                barcode=old_bookspecimen.serial, item=new_book, count=1,
+                comments=old_bookspecimen.remarks,
                 # And now the stuff which hasn't changed
-                location=old_specimen.location, file=old_specimen.file)
-            new_specimen.save()
+                location=old_bookspecimen.location, file=old_bookspecimen.file)
+            new_bookspecimen.save()
 
 
 class Migration(migrations.Migration):

--- a/ideascube/library/tests/test_migrations.py
+++ b/ideascube/library/tests/test_migrations.py
@@ -18,6 +18,231 @@ section_int_to_name = {
 }
 
 
+@migration_test(
+    migrate_from=[
+        ('library', '0007_auto_20161007_1220'),
+        ('monitoring', '0004_auto_20161007_1240'),
+        ('taggit', '0002_auto_20150616_2121'),
+    ], migrate_to=[('library', '0008_library_stock')])
+def test_library_to_monitoring_with_duplicated_data(migration):
+    Book = migration.old_apps.get_model('library', 'Book')
+    BookSpecimen = migration.old_apps.get_model('library', 'BookSpecimen')
+    StockItem = migration.old_apps.get_model('monitoring', 'StockItem')
+    Specimen = migration.old_apps.get_model('monitoring', 'Specimen')
+
+    # Keep for later
+    old_item_ids = []
+    old_specimen_ids = []
+
+    # First, a Book without BookSpecimen
+    Book(section=10, title='Les blagues à Toto').save()
+
+    # Next, a Book with 2 BookSpecimens
+    book = Book(section=99, title='A book which was not in the stock')
+    book.save()
+    BookSpecimen(serial='1234', book_id=book.id).save()
+    BookSpecimen(serial='2345', book_id=book.id).save()
+
+    # Next, a Book with 2 BookSpecimens, the first of which has a Specimen
+    book = Book(
+        section=13, title='Testing Django Applications',
+        subtitle='Volume 1364: Migrations')
+    book.save()
+    BookSpecimen(serial='3456', book_id=book.id).save()
+    BookSpecimen(serial='4567', book_id=book.id).save()
+
+    item = StockItem(name='testing django apps 1364')
+    item.save()
+    old_item_ids.append(item.id)
+    specimen = Specimen(barcode='3456', item_id=item.id)
+    specimen.save()
+    old_specimen_ids.append(specimen.id)
+
+    # Next, a Book with 2 BookSpecimens, the second of which has a Specimen
+    book = Book(
+        section=13, title='Testing Django Applications',
+        subtitle='Volume 1365: Migrations Again')
+    book.save()
+    BookSpecimen(serial='5678', book_id=book.id).save()
+    BookSpecimen(serial='6789', book_id=book.id).save()
+
+    item = StockItem(name='testing django apps 1365')
+    item.save()
+    old_item_ids.append(item.id)
+    specimen = Specimen(barcode='6789', item_id=item.id)
+    specimen.save()
+    old_specimen_ids.append(specimen.id)
+
+    # Next, a Book with 2 BookSpecimens, both of which have a Specimen
+    book = Book(
+        section=13, title='Testing Django Applications',
+        subtitle='Volume 1366: Migrations Forever')
+    book.save()
+    BookSpecimen(serial='7890', book_id=book.id).save()
+    BookSpecimen(serial='8901', book_id=book.id).save()
+
+    item = StockItem(name='testing django apps 1366')
+    item.save()
+    old_item_ids.append(item.id)
+    specimen = Specimen(barcode='7890', item_id=item.id)
+    specimen.save()
+    old_specimen_ids.append(specimen.id)
+    specimen = Specimen(barcode='8901', item_id=item.id)
+    specimen.save()
+    old_specimen_ids.append(specimen.id)
+
+    migration.run_migration()
+
+    Book = migration.new_apps.get_model('library', 'Book')
+    BookSpecimen = migration.new_apps.get_model('library', 'BookSpecimen')
+    StockItem = migration.new_apps.get_model('monitoring', 'StockItem')
+    Specimen = migration.new_apps.get_model('monitoring', 'Specimen')
+
+    assert Book.objects.count() == 5
+    assert BookSpecimen.objects.count() == 8
+    assert StockItem.objects.count() == 5
+    assert Specimen.objects.count() == 8
+
+    books = Book.objects.order_by('name', 'subtitle')
+    bookspecimens = BookSpecimen.objects.order_by('item__name', 'barcode')
+    items = StockItem.objects.order_by('name', 'book__subtitle')
+    specimens = Specimen.objects.order_by('item__name', 'barcode')
+
+    # First, the Book without BookSpecimen
+    book = books[1]
+    assert book.name == 'Les blagues à Toto'
+    assert book.module == 'library'
+    assert book.specimens.count() == 0
+
+    item = items[1]
+    assert item.id not in old_item_ids
+    assert item.book.id == book.id
+    assert item.specimens.count() == 0
+
+    # Next, the Book with 2 BookSpecimens
+    book = books[0]
+    assert book.name == 'A book which was not in the stock'
+    assert book.module == 'library'
+
+    item = items[0]
+    assert item.id not in old_item_ids
+    assert item.book.id == book.id
+    assert item.specimens.count() == 2
+
+    bookspecimen = bookspecimens[0]
+    assert bookspecimen.barcode == '1234'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[0]
+    assert specimen.id not in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+    bookspecimen = bookspecimens[1]
+    assert bookspecimen.barcode == '2345'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[1]
+    assert specimen.id not in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+    # Next, the Book with 2 BookSpecimens, the first of which has a Specimen
+    book = books[2]
+    assert book.name == 'Testing Django Applications'
+    assert book.subtitle == 'Volume 1364: Migrations'
+    assert book.module == 'library'
+
+    item = items[2]
+    assert item.id in old_item_ids
+    assert item.book.id == book.id
+    assert item.specimens.count() == 2
+
+    bookspecimen = bookspecimens[2]
+    assert bookspecimen.barcode == '3456'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[2]
+    assert specimen.id in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+    bookspecimen = bookspecimens[3]
+    assert bookspecimen.barcode == '4567'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[3]
+    assert specimen.id not in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+    # Next, a Book with 2 BookSpecimens, the second of which has a Specimen
+    book = books[3]
+    assert book.name == 'Testing Django Applications'
+    assert book.subtitle == 'Volume 1365: Migrations Again'
+    assert book.module == 'library'
+
+    item = items[3]
+    assert item.id in old_item_ids
+    assert item.book.id == book.id
+    assert item.specimens.count() == 2
+
+    bookspecimen = bookspecimens[4]
+    assert bookspecimen.barcode == '5678'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[4]
+    assert specimen.id not in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+    bookspecimen = bookspecimens[5]
+    assert bookspecimen.barcode == '6789'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[5]
+    assert specimen.id in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+    # Next, a Book with 2 BookSpecimens, both of which have a Specimen
+    book = books[4]
+    assert book.name == 'Testing Django Applications'
+    assert book.subtitle == 'Volume 1366: Migrations Forever'
+    assert book.module == 'library'
+
+    item = items[4]
+    assert item.id in old_item_ids
+    assert item.book.id == book.id
+    assert item.specimens.count() == 2
+
+    bookspecimen = bookspecimens[6]
+    assert bookspecimen.barcode == '7890'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[6]
+    assert specimen.id in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+    bookspecimen = bookspecimens[7]
+    assert bookspecimen.barcode == '8901'
+    assert bookspecimen.serial is None
+    assert bookspecimen.item.book.id == book.id
+
+    specimen = specimens[7]
+    assert specimen.id in old_specimen_ids
+    assert specimen.bookspecimen.id == bookspecimen.id
+    assert specimen.item.id == item.id
+
+
 @migration_test(migrate_from=[('library', '0009_auto_20161027_0801')],
                 migrate_to=[('library', '0010_section_type')])
 def test_section_migration_change_from_int_to_string(migration):


### PR DESCRIPTION
One of the things happening during this migration is that the serial
attribute of the old BookSpecimen model is becoming the barcode
attribute of the Specimen model.

Before this migration, people had to enter their books and specimens
both in the stock (StockItem/Specimen) and in the library
(Book/BookSpecimen).

Because they had to do it in both places, it is very possible that they
had a Specimen with a certain barcode, and a BookSpecimen with the same
serial. (see the first paragraph for how this field maps)

This crashes the migration, because Specimen.barcode has a unicity
constraint.

This commit ensures that the migration still works, removing the
existing StockItem and Specimen, effectively merging them with the new
Book and BookSpecimen.

Fixes #626

---

Note that this is based on @mgautierfr's #619, so let's merge that one first.