### PR TITLE
users: Use the field names when exporting

### DIFF
--- a/ideascube/tests/test_views.py
+++ b/ideascube/tests/test_views.py
@@ -410,8 +410,8 @@ def test_export_users_should_return_csv_with_users(staffapp, settings):
     user2 = UserFactory(short_name="user2", full_name=u"I'm user2 with é")
     resp = staffapp.get(reverse('user_export'), status=200)
     resp.mustcontain(
-        'identifier', user1.serial, user2.serial, no=[
-            'usual name', user1.short_name, user2.short_name,
+        'serial', user1.serial, user2.serial, no=[
+            'short_name', user1.short_name, user2.short_name,
             'full_name', user1.full_name, user2.full_name,
             ])
 
@@ -421,8 +421,7 @@ def test_export_users_should_be_ok_in_arabic(staffapp, settings):
     user1 = UserFactory(serial="جبران خليل جبران")
     user2 = UserFactory(serial="النبي (كتاب)")
     resp = staffapp.get(reverse('user_export'), status=200)
-    field = user_model._meta.get_field('serial')
-    resp.mustcontain(str(field.verbose_name))
+    resp.mustcontain('serial')
     resp.mustcontain(user1.serial)
     resp.mustcontain(user2.serial)
     translation.deactivate()

--- a/ideascube/views.py
+++ b/ideascube/views.py
@@ -222,7 +222,7 @@ class UserExport(CSVExportMixin, View):
     def get_headers(self):
         fields = user_model.get_data_fields()
         self.fields = [f for f in fields if f.name not in user_model.PRIVATE_DATA]
-        return [str(f.verbose_name) for f in self.fields]
+        return [f.name for f in self.fields]
 
     def get_row(self, user):
         data_fields = user.data_fields
@@ -232,7 +232,7 @@ class UserExport(CSVExportMixin, View):
             if value is None:
                 value = ''
             value = str(value)
-            row[str(field.verbose_name)] = value
+            row[field.name] = value
         return row
 user_export = staff_member_required(UserExport.as_view())
 


### PR DESCRIPTION
Using the translated verbose names leads to nicer exports which humans
can better understand and process with their favourite spreadsheet
software.

However, it also means that an Ideascube export can't be imported back
into Ideascube without first renaming the column headers to the field
names.

@barbayellow says user exports have never been used by actual humans,
but only as backups.

Therefore, it seems to make sense to use the field names when exporting.

Fixes #655
Supercedes #656