### PR TITLE
blog: Staff should see more articles

### DIFF
--- a/ideascube/blog/templates/blog/content_card.html
+++ b/ideascube/blog/templates/blog/content_card.html
@@ -4,7 +4,10 @@
     <a href="{% url 'blog:content_detail' pk=content.pk %}">
         <h3>{{ content }}</h3>
     </a>
-    <h5>{{ content.published_at|date:"SHORT_DATE_FORMAT" }} ⚫ {{ content.get_author_display }}</h5>
+    <h5>
+        {% if content.status == content.DRAFT %}draft ⚫ {% endif %}
+        {{ content.published_at|date:"SHORT_DATE_FORMAT" }} ⚫ {{ content.get_author_display }}
+    </h5>
     <p>{% if content.image %}
          <a href="{% url 'blog:content_detail' pk=content.pk %}">
             <img src="{% media content 'image' %}">

--- a/ideascube/blog/tests/test_views.py
+++ b/ideascube/blog/tests/test_views.py
@@ -16,13 +16,31 @@ def test_anonymous_should_access_index_page(app):
     assert app.get(reverse('blog:index'), status=200)
 
 
-def test_only_published_should_be_in_index(app, published, draft, deleted,
-                                           published_in_the_future):
+def test_only_published_should_be_in_index_for_anonymous(
+        app, published, draft, deleted, published_in_the_future):
     response = app.get(reverse('blog:index'))
     assert published.title in response.content.decode()
     assert draft.title not in response.content.decode()
     assert deleted.title not in response.content.decode()
     assert published_in_the_future.title not in response.content.decode()
+
+
+def test_only_published_should_be_in_index_for_users(
+        loggedapp, published, draft, deleted, published_in_the_future):
+    response = loggedapp.get(reverse('blog:index'))
+    assert published.title in response.content.decode()
+    assert draft.title not in response.content.decode()
+    assert deleted.title not in response.content.decode()
+    assert published_in_the_future.title not in response.content.decode()
+
+
+def test_published_and_drafts_and_future_should_be_in_index_for_staff(
+        staffapp, published, draft, deleted, published_in_the_future):
+    response = staffapp.get(reverse('blog:index'))
+    assert published.title in response.content.decode()
+    assert draft.title in response.content.decode()
+    assert deleted.title not in response.content.decode()
+    assert published_in_the_future.title in response.content.decode()
 
 
 def test_index_page_is_paginated(app, monkeypatch):

--- a/ideascube/blog/views.py
+++ b/ideascube/blog/views.py
@@ -21,9 +21,16 @@ class Index(FilterableViewMixin, OrderableViewMixin, ListView):
     ]
 
     model = Content
-    queryset = Content.objects.published()
     template_name = 'blog/index.html'
     paginate_by = 10
+
+    def get_queryset(self):
+        qs = super().get_queryset().exclude(status=Content.DELETED)
+
+        if not self.request.user.is_staff:
+            qs = qs.published()
+
+        return qs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
The staff really should be able to see draft articles in the blog index, as well as articles which will be published in the future.

Otherwise, it's a bit hard for them to edit them.

Fixes #528