### PR TITLE
Add a `migrate` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ install:
 	sudo dpkg -i builds/*.deb
 uninstall:
 	sudo dpkg -r ideascube
+migrate:
+	python3 manage.py migrate --database=default
+	python3 manage.py migrate --database=transient

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,7 +71,7 @@ Install python dependencies:
 
 Run the initial database migration::
 
-    python3 manage.py migrate
+    make migrate
 
 To populate the database with some initial dummy data, you can run the command::
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -29,19 +29,16 @@ Run the tests:
 
 And run the migrations:
 
-    $ python manage.py migrate --database=default
-    $ python manage.py migrate --database=transient
+    $ make migrate
 
 Let's make sure there are no migration conflicts:
 
     $ rm -fr storage
     $ git checkout $TAG_FOR_LATEST_RELEASE
-    $ python manage.py migrate --database=default
-    $ python manage.py migrate --database=transient
+    $ make migrate
     $ make dummydata
     $ git checkout master
-    $ python manage.py migrate --database=default
-    $ python manage.py migrate --database=transient
+    $ make migrate
 
 Ideally, in the above steps, it would be even better to use a real-world
 database (from a server running the latest release) instead of the dummy data.


### PR DESCRIPTION
I just keep on forgetting to run the migrations on both databases, so
let's make it easier on ourselves.