### PR TITLE
Some i18n changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ doc:
 dummydata:
 	python3 manage.py dummydata
 collect_translations:
-	python3 manage.py makemessages -a --ignore=debian
-	python3 manage.py makemessages -d djangojs -a --ignore=debian
+	python3 manage.py makemessages -a --ignore=debian -d django
+	python3 manage.py makemessages -a --ignore=debian -d djangojs
 push_translations:
 	tx push -s
 pull_translations:

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ doc:
 dummydata:
 	python3 manage.py dummydata
 collect_translations:
-	python3 manage.py makemessages --all --ignore=debian -d django
-	python3 manage.py makemessages --all --ignore=debian -d djangojs
+	python3 manage.py makemessages --all --no-obsolete --ignore=debian -d django
+	python3 manage.py makemessages --all --no-obsolete --ignore=debian -d djangojs
 push_translations:
 	tx push -s
 pull_translations:

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ doc:
 dummydata:
 	python3 manage.py dummydata
 collect_translations:
-	python3 manage.py makemessages -a --ignore=debian -d django
-	python3 manage.py makemessages -a --ignore=debian -d djangojs
+	python3 manage.py makemessages --all --ignore=debian -d django
+	python3 manage.py makemessages --all --ignore=debian -d djangojs
 push_translations:
 	tx push -s
 pull_translations:


### PR DESCRIPTION
Just a few changes to the `Makefile`, hopefully making it just a tiny bit more readable.

In addition, we now remove obsolete strings from the generated `.po` files, to avoid asking translators to do unnecessary work.