### PR TITLE
Use the `=` sign for the progress bars

### DIFF
--- a/ideascube/mediacenter/management/commands/import_medias.py
+++ b/ideascube/mediacenter/management/commands/import_medias.py
@@ -19,7 +19,6 @@ from ideascube.management.utils import Reporter
 
 class Bar(ProgressBar):
     template = 'Import: {percent} |{animation}| {done}/{total} | ETA: {eta}'
-    done_char = '⬛'
 
 
 class Command(BaseCommand):

--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -443,7 +443,6 @@ class ZippedMedias(SimpleZipPackage):
 class Bar(ProgressBar):
     template = ('Download: {percent} |{animation}| {done:B}/{total:B} '
                 '({speed:B}/s) | ETA: {eta}')
-    done_char = '⬛'
     throttle = timedelta(seconds=1)
 
 


### PR DESCRIPTION
That unicode black square makes for very pretty progress bars.

Until you change your font, and the square suddenly has space on its
left and right sides, and these spaces are unaccounted for when
calculating the width, and the line gets broken and it looks terrible.

In addition, we regularly have encoding errors because of it when
running the commands through an SSH connexion, with different locales
installed on the client and the server.

So let's go back to simplicity.