### PR TITLE
Import from Llave del Saber

### DIFF
--- a/ideascube/conf/idb_col_llavedelsaber.py
+++ b/ideascube/conf/idb_col_llavedelsaber.py
@@ -9,3 +9,8 @@ ALLOWED_HOSTS = ['.bibliotecamovil.lan', 'localhost']
 USER_FORM_FIELDS = USER_FORM_FIELDS + (  # pragma: no flakes
         (_('Personal informations'), ['disabilities']),
 )
+
+USER_IMPORT_FORMATS = (
+    ('llavedelsaber', 'Llave del Saber'),
+    ('ideascube', 'Ideascube'),
+)

--- a/ideascube/forms.py
+++ b/ideascube/forms.py
@@ -89,6 +89,15 @@ class UserImportForm(forms.Form):
     def _get_ideascube_mapping(self, data):
         return data
 
+    def _get_llavedelsaber_reader(self, source):
+        return csv.DictReader(source, delimiter=';', quoting=csv.QUOTE_ALL)
+
+    def _get_llavedelsaber_mapping(self, data):
+        # TODO: Implement the rest, once we hear back from Sergio
+        return {
+            'serial': data['serial'],
+        }
+
     def save(self):
         format = self.cleaned_data['format']
         source = TextIOWrapper(self.cleaned_data['source'].file)

--- a/ideascube/forms.py
+++ b/ideascube/forms.py
@@ -108,13 +108,13 @@ class UserImportForm(forms.Form):
         users = []
         errors = []
 
-        for idx, row in enumerate(reader(source)):
+        for idx, row in enumerate(reader(source), start=1):
             try:
                 row = mapper(row)
 
             except KeyError as e:
                 msg = _('Invalid row at line {id}: {field} missing')
-                errors.append(msg.format(id=idx + 1, field=e.args[0]))
+                errors.append(msg.format(id=idx, field=e.args[0]))
                 continue
 
             try:
@@ -129,5 +129,5 @@ class UserImportForm(forms.Form):
                 reason = ', '.join('{}: {}'.format(k, v.as_text())
                                    for k, v in form.errors.items())
                 errors.append(_('Invalid row at line {id}: {reason}').format(
-                    id=idx + 1, reason=reason))
+                    id=idx, reason=reason))
         return users, errors[:10]

--- a/ideascube/templates/ideascube/user_import.html
+++ b/ideascube/templates/ideascube/user_import.html
@@ -1,17 +1,9 @@
-{% extends 'base.html' %}
+{% extends 'form-fullpage.html' %}
 
 {% load i18n %}
 
-{% block content %}
-    <div class="row">
-        <h2>{% trans "Import users" %}</h2>
-    </div>
-    <div class="row">
-        <form method="POST" enctype="multipart/form-data" id="import">
-            {% csrf_token %}
-            <label>{% trans 'Please select a CSV file to import.' %}</label><br />
-            {{ form.source }}
-            <input type="submit" value="{% trans 'Import' %}">
-        </form>
-    </div>
-{% endblock content %}
+{% block heading %}
+    <h2>{% trans "Import users" %}</h2>
+{% endblock %}
+
+{% block form_id %}import{% endblock %}

--- a/ideascube/tests/test_import_users.py
+++ b/ideascube/tests/test_import_users.py
@@ -222,6 +222,56 @@ def test_does_not_try_to_create_system_user(staffapp, monkeypatch):
     assert user.full_name != 'ANewFunkyName'
 
 
+def test_import_from_llavedelsaber_format(staffapp, settings):
+    settings.USER_IMPORT_FORMATS = (
+        ('llavedelsaber', 'Llave del Saber'),
+        ('ideascube', 'Ideascube'),
+    )
+
+    # TODO: The format of Llave del Saber exports is not finalized
+    data = '\n'.join([
+        '"serial";"a_field";"another_field";"a_third_field";"last_field"',
+        '"206678478";"";"";"";""',
+        '"206678201";"";"";"";""',
+    ])
+
+    form = staffapp.get(reverse('user_import')).forms['import']
+    form['format'] = 'llavedelsaber'
+    form['source'] = Upload('users.csv', data.encode('utf-8'), 'text/csv')
+    form.submit(status=302).follow(status=200)
+
+    users = User.objects.all().order_by('serial')
+    assert users.count() == 3  # The two imported, plus the staff
+
+    # TODO: Test the other imported fields eventually
+    serials = [u.serial for u in users]
+    assert serials == ['123456staff', '206678201', '206678478']
+
+
+def test_import_from_llavedelsaber_format_invalid_data(staffapp, settings):
+    settings.USER_IMPORT_FORMATS = (
+        ('llavedelsaber', 'Llave del Saber'),
+        ('ideascube', 'Ideascube'),
+    )
+
+    # TODO: The format of Llave del Saber exports is not finalized
+    data = '\n'.join([
+        '"llave";"a_field";"another_field";"a_third_field";"last_field"',
+        '"206678478";"";"";"";""',
+        '"206678201";"";"";"";""',
+    ])
+
+    form = staffapp.get(reverse('user_import')).forms['import']
+    form['format'] = 'llavedelsaber'
+    form['source'] = Upload('users.csv', data.encode('utf-8'), 'text/csv')
+    response = form.submit(status=302).follow(status=200)
+    assert 'Invalid row at line 1: serial missing' in response.text
+    assert 'Invalid row at line 2: serial missing' in response.text
+
+    users = User.objects.all()
+    assert users.count() == 1  # The staff
+
+
 def test_import_from_invalid_format(staffapp, settings):
     settings.USER_IMPORT_FORMATS = (
         ('llavedelsaber', 'Llave del Saber'),

--- a/ideascube/tests/test_settings.py
+++ b/ideascube/tests/test_settings.py
@@ -14,6 +14,12 @@ def setting_module(request):
 
 
 def test_setting_file(setting_module):
+    from ideascube.forms import UserImportForm
+
     settings = importlib.import_module(setting_module, package="ideascube")
 
     assert isinstance(getattr(settings, 'IDEASCUBE_NAME', ''), str)
+
+    for name, _ in getattr(settings, 'USER_IMPORT_FORMATS', []):
+        assert hasattr(UserImportForm, '_get_{}_mapping'.format(name))
+        assert hasattr(UserImportForm, '_get_{}_reader'.format(name))


### PR DESCRIPTION
I had to take a bit of a detour in order to do this the way we wanted.

First, this branch introduces a new widget, the ComboBoxEntry, which is inexplicably absent from HTML.

Second, the `current_occupation` and `school_level` fields of the `User` model are changed to accept any value, but use the ComboBoxEntry as a widget so that we still show a default list to try and guide users towards always using the same values. Custom values get added to the list the first time they are used.

Third, a few of these values are added or renamed, as we found the current lists weren't perfect.

Finally, the user import process is made to optionally accept data in the Llave del Saber format, and try mapping their values to ours when it makes sense.

Relates to #662 