### PR TITLE
Add a command to remove orphan files from the mediacenter.

### DIFF
--- a/ideascube/mediacenter/management/commands/clean.py
+++ b/ideascube/mediacenter/management/commands/clean.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+import os
+import argparse
+import glob
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from ideascube.mediacenter.models import Document
+from ideascube.utils import printerr
+
+
+class Command(BaseCommand):
+    help = 'Remove files from the mediacenter.'
+
+    def add_arguments(self, parser):
+        subs = parser.add_subparsers(
+            title='Commands', dest='cmd', metavar='',
+            parser_class=argparse.ArgumentParser)
+        clean_leftover = subs.add_parser(
+            'leftover-files',
+            help='Clean mediacenter files not associated with a document.')
+        clean_leftover.set_defaults(func=self.clean_leftover)
+        parser.add_argument('--dry-run', action='store_true',
+                            help='Print the list of medias that would be '
+                                 'removed. Do not actually remove them')
+
+    def handle(self, *args, **options):
+        if 'func' not in options:
+            self.parser.print_help()
+            self.parser.exit(1)
+
+        options['func'](options)
+
+    def clean_leftover(self, options):
+        files_to_remove = self._get_leftover_files()
+        if options['dry_run']:
+            print("Files to remove are :")
+            for _file in files_to_remove:
+                print(" - '{}'".format(_file))
+        else:
+            for f in files_to_remove:
+                try:
+                    os.unlink(f)
+                except Exception as e:
+                    printerr("ERROR while deleting {}".format(f))
+                    printerr("Exception is {}".format(e))
+
+    def _get_leftover_files(self):
+        # List all (original and preview) files in the fs
+        original_files_root_dir = os.path.join(settings.MEDIA_ROOT,
+                                               'mediacenter/document')
+        files_in_fs = set(
+            glob.iglob(os.path.join(original_files_root_dir, '*')))
+
+        preview_files_root_dir = os.path.join(settings.MEDIA_ROOT,
+                                    'mediacenter/preview')
+        files_in_fs.update(
+            glob.iglob(os.path.join(preview_files_root_dir, '*')))
+
+        # Remove known original paths.
+        original_pathes = Document.objects.all().values_list(
+            'original', flat=True)
+        original_pathes = (os.path.join(settings.MEDIA_ROOT, path)
+                           for path in original_pathes)
+        files_in_fs.difference_update(original_pathes)
+
+        # Remove known preview paths.
+        preview_pathes = Document.objects.all().values_list(
+            'preview', flat=True)
+        preview_pathes = (os.path.join(settings.MEDIA_ROOT, path)
+                          for path in preview_pathes if path)
+        files_in_fs.difference_update(preview_pathes)
+
+        return files_in_fs

--- a/ideascube/mediacenter/tests/factories.py
+++ b/ideascube/mediacenter/tests/factories.py
@@ -4,12 +4,15 @@ import factory
 
 from ..models import Document
 
+class EmptyFileField(factory.django.FileField):
+    DEFAULT_FILENAME = None
 
 class DocumentFactory(factory.django.DjangoModelFactory):
     title = factory.Sequence(lambda n: "Test document {0}".format(n))
     summary = "This is a test summary"
     lang = settings.LANGUAGE_CODE
     original = factory.django.FileField()
+    preview = EmptyFileField()
     credits = "Document credits"
     package_id = ""
 

--- a/ideascube/mediacenter/tests/test_clean.py
+++ b/ideascube/mediacenter/tests/test_clean.py
@@ -1,0 +1,140 @@
+import os, stat
+import pytest
+
+from django.core.management import call_command
+from django.core.files import File
+
+from ideascube.mediacenter.models import Document
+from .factories import DocumentFactory
+
+pytestmark = pytest.mark.django_db
+
+DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+
+
+def test_clean_leftover_should_not_fail_if_no_media_or_file():
+    call_command('clean', 'leftover-files')
+
+
+def test_clean_leftover_should_not_remove_files_associated_with_documents(settings):
+    document = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                               preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+    original_path = document.original.path
+    preview_path = document.preview.path
+    assert os.path.exists(original_path)
+    assert os.path.exists(preview_path)
+    call_command('clean', 'leftover-files')
+    assert os.path.exists(original_path)
+    assert os.path.exists(preview_path)
+
+
+def test_clean_leftover_should_not_remove_files_associated_with_documents_without_preview(settings):
+    document = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                               preview=None)
+    original_path = document.original.path
+    assert os.path.exists(original_path)
+    call_command('clean', 'leftover-files')
+    assert os.path.exists(original_path)
+
+
+def test_clean_leftover_should_correctly_remove_orphan_files(settings):
+    document = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                               preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+    original_path = document.original.path
+    preview_path = document.preview.path
+    Document.objects.all().delete()
+    assert os.path.exists(original_path)
+    assert os.path.exists(preview_path)
+    call_command('clean', 'leftover-files')
+    assert not os.path.exists(original_path)
+    assert not os.path.exists(preview_path)
+
+
+def test_clean_leftover_should_fail_nicely_if_cannot_remove(settings, capsys):
+    document = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                               preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+    original_path = document.original.path
+    preview_path = document.preview.path
+    document.delete()
+    assert os.path.exists(original_path)
+    assert os.path.exists(preview_path)
+    os.chmod(os.path.join(settings.MEDIA_ROOT, 'mediacenter/document'), stat.S_IRUSR | stat.S_IXUSR)
+    call_command('clean', 'leftover-files')
+    assert os.path.exists(original_path)
+    assert not os.path.exists(preview_path)
+    _, err = capsys.readouterr()
+    assert "ERROR while deleting {}".format(original_path) in err
+
+
+def test_clean_leftover_should_not_remove_orphan_files_if_dry_run(settings, capsys):
+    document = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                               preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+    original_path = document.original.path
+    preview_path = document.preview.path
+    Document.objects.all().delete()
+    assert os.path.exists(original_path)
+    assert os.path.exists(preview_path)
+    call_command('clean', 'leftover-files', dry_run=True)
+    assert os.path.exists(original_path)
+    assert os.path.exists(preview_path)
+    out, _ = capsys.readouterr()
+    assert original_path in out
+    assert preview_path in out
+
+
+def test_clean_leftover_should_correctly_clean_after_document_update(settings):
+    document = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                               preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+    old_original_path = document.original.path
+    preview_path = document.preview.path
+    with open(os.path.join(DATA_PATH, 'a-pdf.pdf'), 'rb') as f:
+        document.original = File(f, name='a-pdf.pdf')
+        document.save()
+    new_original_path = document.original.path
+    assert os.path.exists(old_original_path)
+    assert os.path.exists(new_original_path)
+    assert os.path.exists(preview_path)
+    call_command('clean', 'leftover-files')
+    assert not os.path.exists(old_original_path)
+    assert os.path.exists(new_original_path)
+    assert os.path.exists(preview_path)
+
+
+def test_clean_leftover_should_correctly_clean_after_complex_situation(settings):
+    document0 = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                                preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+    document1 = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                                preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+    document2 = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                                preview=None)
+    document3 = DocumentFactory(original__from_path=os.path.join(DATA_PATH, 'a-video.mp4'),
+                                preview__from_path=os.path.join(DATA_PATH, 'an-image.jpg'))
+
+    file_that_should_be_deleted = [
+        document1.original.path,
+        document1.preview.path,
+        document3.original.path,
+        document3.preview.path
+    ]
+    document1.delete()
+    with open(os.path.join(DATA_PATH, 'a-pdf.pdf'), 'rb') as f:
+        document3.original = File(f, name='a-pdf.pdf')
+        document3.save()
+    with open(os.path.join(DATA_PATH, 'an-image.jpg'), 'rb') as f:
+        document3.preview = File(f, name='an-image2.jpg')
+        document3.save()
+
+    files_that_should_be_kept = [
+        document0.original.path,
+        document0.preview.path,
+        document2.original.path,
+        document3.original.path,
+        document3.preview.path
+    ]
+
+    call_command('clean', 'leftover-files')
+    for path in file_that_should_be_deleted:
+        assert not os.path.exists(path)
+    for path in files_that_should_be_kept:
+        assert os.path.exists(path)
+


### PR DESCRIPTION
This PR add a command to remove orphan files from the mediacenter.

After discussion on PR #686, we agree that a command to remove orphan would be a better idea than
add a listener on the `post_delete` signal.
With a command we handle the delete case (#684) and the update case (#457)

Fixes #684 and Fixes #457