### PR TITLE
Fix the clean command

### DIFF
--- a/ideascube/mediacenter/management/commands/clean.py
+++ b/ideascube/mediacenter/management/commands/clean.py
@@ -25,6 +25,8 @@ class Command(BaseCommand):
                             help='Print the list of medias that would be '
                                  'removed. Do not actually remove them')
 
+        self.parser = parser
+
     def handle(self, *args, **options):
         if 'func' not in options:
             self.parser.print_help()


### PR DESCRIPTION
Without this, it couldn't print its own help text when invoked without a
subcommand.