### PR TITLE
Use a non-UTF8 locale to run the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "3.4"
+env:
+  - LC_ALL=en_US.UTF-8
+  - LC_ALL=C
 sudo: false
 branches:
   only:

--- a/ideascube/library/tests/test_utils.py
+++ b/ideascube/library/tests/test_utils.py
@@ -1,27 +1,27 @@
 from ..utils import fetch_from_openlibrary, load_from_moccam_csv, load_unimarc
 
 
-def test_load_from_moccam_csv(monkeypatch):
+def test_load_from_moccam_csv(monkeypatch, testdatadir):
     monkeypatch.setattr('ideascube.library.utils.load_cover_from_url',
                         lambda x: 'xxx')
-    with open('ideascube/library/tests/data/moccam.csv') as f:
-        notices = list(load_from_moccam_csv(f.read()))
-        assert len(notices) == 2
-        notice, cover = notices[0]
-        assert notice['name'] == 'Les Enchanteurs'
-        assert notice['authors'] == 'Romain Gary'
-        assert notice['publisher'] == 'Gallimard'
-        assert notice['description'].startswith('Le narrateur')
-        assert cover == 'xxx'
+    moccam = testdatadir.join('moccam.csv').read_text('utf-8')
+    notices = list(load_from_moccam_csv(moccam))
+    assert len(notices) == 2
+    notice, cover = notices[0]
+    assert notice['name'] == 'Les Enchanteurs'
+    assert notice['authors'] == 'Romain Gary'
+    assert notice['publisher'] == 'Gallimard'
+    assert notice['description'].startswith('Le narrateur')
+    assert cover == 'xxx'
 
 
-def test_load_unimarc(monkeypatch):
-    with open('ideascube/library/tests/data/marc.dat') as f:
-        notices = [notice for notice, cover in load_unimarc(f.read())]
-        assert len(notices) == 20
-        assert notices[0]['name'] == 'The pragmatic programmer : from journeyman to master /'  # noqa
-        assert notices[0]['authors'] == 'Hunt, Andrew, 1964-'
-        assert notices[0]['publisher'] == 'Addison-Wesley,'
+def test_load_unimarc(monkeypatch, testdatadir):
+    unimarc = testdatadir.join('marc.dat').read_text('utf-8')
+    notices = [notice for notice, cover in load_unimarc(unimarc)]
+    assert len(notices) == 20
+    assert notices[0]['name'] == 'The pragmatic programmer : from journeyman to master /'  # noqa
+    assert notices[0]['authors'] == 'Hunt, Andrew, 1964-'
+    assert notices[0]['publisher'] == 'Addison-Wesley,'
 
 
 def test_fetch_from_openlibrary(monkeypatch):

--- a/ideascube/library/tests/test_views.py
+++ b/ideascube/library/tests/test_views.py
@@ -348,7 +348,7 @@ def test_import_from_files(staffapp, monkeypatch):
 def test_import_from_files_does_not_duplicate(staffapp, monkeypatch):
     monkeypatch.setattr('ideascube.library.utils.read_url', lambda x: None)
     path = 'ideascube/library/tests/data/moccam.csv'
-    with open(path) as f:
+    with open(path, encoding='utf-8') as f:
         isbn = f.read().split('\t')[0]
     # Create a book with same isbn as first entry of CSV.
     BookFactory(isbn=isbn)

--- a/ideascube/monitoring/tests/test_views.py
+++ b/ideascube/monitoring/tests/test_views.py
@@ -111,15 +111,15 @@ def test_books_are_not_exported(staffapp):
 
 def test_import_stock(staffapp, tmpdir):
     source = tmpdir.join('stock.csv')
-    source.write(
+    source.write_text(
         'module,name,description\n'
         'cinema,C\'est arrivé près de chez vous,"Conte féérique pour les '
         'petits et les grands, le film relate les aventures de Benoît, preux '
         'chevalier en quête de justice, et des ménestrels Rémy, André et '
         'Patrick.\n\nBenoît parviendra-t-il à leur enseigner le principe de '
         'la poussée d\'Archimède ? Patrick reverra-t-il Marie-Paule ?"\n'
-        'notamodule,Not a name,This is not a description.\n'
-        )
+        'notamodule,Not a name,This is not a description.\n',
+        encoding='utf-8')
 
     response = staffapp.get(reverse('monitoring:stock_import'))
     form = response.forms['import']

--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -39,7 +39,7 @@ def rm(path):
 
 
 def load_from_file(path):
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         return yaml.safe_load(f.read())
 
 
@@ -48,7 +48,7 @@ def persist_to_file(path, data):
 
     Note: The function assumes that the data is serializable.
     """
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(yaml.safe_dump(data, default_flow_style=False))
 
 


### PR DESCRIPTION
The default encoding on Python 3 is the one from the current locale.
This almost always means UTF-8, at least for our target deployment
(Debian Jessie with a UTF-8 locale)

And that's a great thing. It's not necessary to think about encoding
issues most of the time, and that's liberating.

However, BSF manages the boxes in two ways.

The first is to connect to them from their (usually Debian, Ubuntu or
Mint) workstations with SSH, through a bastion. The default
configuration for the SSH client on these OS makes the remote session
use the locale of the local session (usually fr_FR.UTF8).

But on Debian, not all locales are installed by default. This means that
the remote session will try to use a locale (from the local session)
which is not installed on the server.

When that happens, the session falls back to the C locale, for which the
default encoding is ASCII.

The second management method is through a NetworkManager dispatcher
script, which runs ansible-pull to get the latest ansiblecube state and
run it. This also tends to run in a C locale, for which the default
encoding is ASCII.

This means that in Ideascube we can't be our usual lazy Python
developers and assume a UTF-8 encoding. We must instead start specifying
explicitly the correct encoding.

This commit makes sure we run the tests under the C locale, and
therefore with the ASCII default encoding, to catch lots of these
issues.

It won't catch all of them, but it will help us eliminate some of them
and get into the habit of always explicitly specifying the UTF-8
encoding.

And when we find an issue in production which wasn't caught by tests, we
can add more tests to prevent it from coming back.

---

And in fact, it already catches some, so the subsequent commits fix them. 😄 