### PR TITLE
Check that index file is really present before adding it to library.xml

### DIFF
--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -163,7 +163,10 @@ class Kiwix(Handler):
 
                 book = books[0]
                 book.set('path', 'data/content/%s' % zimname)
-                book.set('indexPath', 'data/index/%s.idx' % zimname)
+
+                index_path = 'data/index/%s.idx' % zimname
+                if os.path.isdir(os.path.join(self._install_dir, index_path)):
+                    book.set('indexPath', index_path)
 
                 library.append(book)
 


### PR DESCRIPTION
Not all zim come with a corresponding index.
If there is no index file, we should not add it to library xml.