### PR TITLE
Add a command to clean tags.

### DIFF
--- a/ideascube/management/commands/tags.py
+++ b/ideascube/management/commands/tags.py
@@ -1,10 +1,13 @@
 import argparse
 import sys
+from itertools import groupby
+from operator import itemgetter
 
 from django.core.management.base import BaseCommand
 from django.utils.termcolors import colorize
 
 from taggit.models import Tag, TaggedItem
+from ideascube.utils import sanitize_tag_name
 
 
 def log(text, **kwargs):
@@ -49,6 +52,11 @@ class Command(BaseCommand):
         replace.add_argument('old', help='Old tag name.')
         replace.add_argument('new', help='New tag name.')
         replace.set_defaults(func=self.replace)
+
+        sanitize = subs.add_parser('sanitize',
+            help=('Sanitize existing tags.\n'
+                  'Remove duplicates, clean characters...'))
+        sanitize.set_defaults(func=self.sanitize)
 
         list_ = subs.add_parser('list', help='List tags')
         list_.set_defaults(func=self.list)
@@ -121,3 +129,57 @@ class Command(BaseCommand):
         print(row.format('.' * 40, '.' * 40, '.' * 40))
         for tag in Tag.objects.order_by('slug'):
             print(row.format(tag.name, tag.slug, self._count(tag.name)))
+
+    def sanitize(self, options):
+        all_tags = ((sanitize_tag_name(t.name), t) for t in Tag.objects.all())
+        all_tags = sorted(all_tags, key=itemgetter(0))
+        all_tags = groupby(all_tags, key=itemgetter(0))
+        for new_tag_name, tags in all_tags:
+            tags = (t[1] for t in tags)
+            if not new_tag_name:
+                # No need to delete relation, happy cascading !
+                for tag in tags:
+                    tag.delete()
+                continue
+
+            tag = next(tags)
+            other_equivalent_tags = list(tags)
+
+            # All the relations we need to redirect to `tag`
+            other_relations = TaggedItem.objects.filter(
+                tag__in=other_equivalent_tags)
+            for relation in other_relations:
+                # if an object `o` is tagged with tag `foo` and `Foo`, the
+                # relation `o-Foo` must be change to `o-foo`. But this relation
+                # already exists, so, instead, we must delete `o-Foo`,
+                # not change it.
+                existing_relations = TaggedItem.objects.filter(
+                        tag=tag,
+                        object_id=relation.content_object.id,
+                        content_type = relation.content_type)
+                if not existing_relations.exists():
+                    # We must change the relation
+                    relation.tag = tag
+                    relation.save()
+                else:
+                    # We have existing relation(s).
+                    # We should not have more than one because we cannot have
+                    # the *exact* same relation twice but let's be safe :
+                    # delete any extra relation.
+                    extra_relations = list(existing_relations)[1:]
+                    for rel in extra_relations:
+                        rel.delete()
+                    # Then delete the current relation because we know we have
+                    # an existing relation.
+                    relation.delete()
+
+            # There is no relation to other tags left, delete them.
+            for t in other_equivalent_tags:
+                t.delete()
+
+            # Be sure our tag is correctly renamed.
+            # We do it at the end because the tag's name is unique and so,
+            # we want to be sure that all potential duplicates have been
+            # deleted/changed.
+            tag.name = new_tag_name
+            tag.save()

--- a/ideascube/mediacenter/models.py
+++ b/ideascube/mediacenter/models.py
@@ -106,7 +106,7 @@ class Document(SearchMixin, TimeStampedModel):
 
     @property
     def index_tags(self):
-        return self.tags.slugs()
+        return list(self.tags.slugs()) + list(self.tags.names())
 
     @property
     def slug(self):

--- a/ideascube/search/models.py
+++ b/ideascube/search/models.py
@@ -36,7 +36,7 @@ class TagMatch(models.Lookup):
         out = '({0} LIKE {1})'.format(lhs, rhs)
         out = ' AND '.join([out]*len(params))
         out = '({})'.format(out)
-        return out, ['%|{}|%'.format(p) for p in params]
+        return out, ['%|{}|%'.format(p.lower()) for p in params]
 
 
 class SearchTagField(models.Field):

--- a/ideascube/search/tests/test_models.py
+++ b/ideascube/search/tests/test_models.py
@@ -97,6 +97,18 @@ def test_search_Document_multiple_tag():
 
 
 @pytest.mark.usefixtures('cleansearch')
+def test_search_Document_on_tag_name_and_slug():
+    doc1 = DocumentFactory(tags=["aé"])
+    doc2 = DocumentFactory(tags=["ae"])
+
+    assert doc1 in Search.search(tags__match=["ae"])
+    assert doc2 in Search.search(tags__match=["ae"])
+
+    assert doc1 in Search.search(tags__match=["aé"])
+    assert doc2 not in Search.search(tags__match=["aé"])
+
+
+@pytest.mark.usefixtures('cleansearch')
 def test_more_relevant_should_come_first():
     second = ContentFactory(title="About music and music")
     third = ContentFactory(title="About music")

--- a/ideascube/search/tests/test_models.py
+++ b/ideascube/search/tests/test_models.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from operator import attrgetter
+
 from ideascube.blog.tests.factories import ContentFactory
 from ideascube.blog.models import Content
 from ideascube.mediacenter.models import Document
 from ideascube.mediacenter.tests.factories import DocumentFactory
+from ideascube.utils import sanitize_tag_name
 from ..models import Search
 
 
@@ -106,6 +109,23 @@ def test_search_Document_on_tag_name_and_slug():
 
     assert doc1 in Search.search(tags__match=["aé"])
     assert doc2 not in Search.search(tags__match=["aé"])
+
+
+@pytest.mark.usefixtures('cleansearch')
+def test_search_Document_is_case_insensitive():
+    # The custom function to parse tag string (and so sanitize tag's names)
+    # is used is form only, not if we use `tag.set()` or `tag.add()`.
+    # DocumentFactory use `tag.add()` to set the tags of the document and so
+    # the tag's names are not sanitized.
+    doc1 = DocumentFactory(tags=[sanitize_tag_name("aé")])
+    doc2 = DocumentFactory(tags=[sanitize_tag_name("AÉ")])
+    doc3 = DocumentFactory(tags=[sanitize_tag_name("Bar")])
+
+    assert sorted(Search.search(tags__match=["aé"]), key=attrgetter('id')) \
+        == [doc1, doc2]
+    assert sorted(Search.search(tags__match=["AÉ"]), key=attrgetter('id')) \
+        == [doc1, doc2]
+    assert doc3 in Search.search(tags__match=["baR"])
 
 
 @pytest.mark.usefixtures('cleansearch')

--- a/ideascube/tests/test_utils.py
+++ b/ideascube/tests/test_utils.py
@@ -58,13 +58,13 @@ def test_size(tmpdir):
 
 
 @pytest.mark.parametrize('string', [
-    'foo,bar,stuff,fuzzy',
-    'foo, bar, stuff, fuzzy',
-    'bar, stuff; fuzzy, foo',
-    ';;;; bar,   stuff    ;,fuzzy,foo  '
+    'foo,bar,stuff:fuzzy',
+    'foo, bar, stuff:fuzzy',
+    'bar, stuff:fuzzy; foo',
+    ';;;; bar,   *stuff:fuzzy---,foo  ',
 ])
 def test_tag_splitter_simple_tags(string):
-    oracle = set(['foo', 'bar', 'stuff', 'fuzzy'])
+    oracle = set(['foo', 'bar', 'stuff:fuzzy'])
     tags = tag_splitter(string)
     assert len(tags) == len(oracle)
     assert set(tags) == oracle
@@ -82,8 +82,8 @@ def test_tag_splitter_tags_with_spaces(string):
     assert len(tags) == len(oracle)
     assert set(tags) == oracle
 
-def test_different_cases_make_different_tags():
-    oracle = set(['bar', 'Bar', 'BAR', 'baR'])
+def test_different_cases_make_same_tags():
+    oracle = set(['bar'])
     tags = tag_splitter("bar, Bar, BAR, baR")
     assert len(tags) == len(oracle)
     assert set(tags) == oracle

--- a/ideascube/utils.py
+++ b/ideascube/utils.py
@@ -89,6 +89,11 @@ def get_file_sha256(path):
 def get_file_size(path):
     return os.stat(path).st_size
 
+def sanitize_tag_name(tag_name):
+    tag_name = tag_name.strip(';:.,?!+-@+-/* \t')
+    tag_name = tag_name.lower()
+    return tag_name
+
 def tag_splitter(tag_string):
     tags = set(t.strip() for t in re.split(r'[;,]+', tag_string) if t.strip())
     return list(tags)

--- a/ideascube/utils.py
+++ b/ideascube/utils.py
@@ -95,5 +95,5 @@ def sanitize_tag_name(tag_name):
     return tag_name
 
 def tag_splitter(tag_string):
-    tags = set(t.strip() for t in re.split(r'[;,]+', tag_string) if t.strip())
-    return list(tags)
+    tags = set(sanitize_tag_name(t) for t in re.split(r'[;,]+', tag_string))
+    return list(tag for tag in tags if tag)


### PR DESCRIPTION
Before ideascube version 0.9, we were using case-sensitive taggit.
Then at this time, taggit were creating two different tags for 'Foo' and
'foo'.

But now, with more recent versions, we are in case-insensitive. Then
taggit assumes there is only one tag for a (insensitive) string.
So if we try to tag a object with tag 'foo', taggit crashes because the
assumption is not fulfill.

This new command "tags sanitize" fixes this by merging (insensitive) equal
tags. After running it, we end with the same situation as if we were all
the time in case-insensitive setting.

This command also clean the tag names. It remove punctuation characters and
remove tags with empty names.