### PR TITLE
Remove -e in requirements(-dev).txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ migrate:
 upgrade-deps:
 	pip-compile --rebuild --header --index --annotate  requirements.in
 	pip-compile --rebuild --header --index --annotate  requirements-dev.in
+	# Remove -e in the requirements(-dev).txt.
+	# See issue : https://github.com/spotify/dh-virtualenv/issues/200
+	sed -i 's/^-e //g' requirements.txt
+	sed -i 's/^-e //g' requirements-dev.txt
 
 sync-deps:
 	pip-sync requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file requirements-dev.txt requirements-dev.in
 #
--e git+https://github.com/ideascube/dbus-python.git@pipified-1.1.1#egg=dbus-python
--e git+https://github.com/ideascube/django-select-multiple-field@remove-dj110-warning#egg=django-select-multiple-field
+git+https://github.com/ideascube/dbus-python.git@pipified-1.1.1#egg=dbus-python
+git+https://github.com/ideascube/django-select-multiple-field@remove-dj110-warning#egg=django-select-multiple-field
 apipkg==1.4               # via execnet
 batinfo==0.4.2
 beautifulsoup4==4.5.3     # via webtest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
--e git+https://github.com/ideascube/dbus-python.git@pipified-1.1.1#egg=dbus-python
--e git+https://github.com/ideascube/django-select-multiple-field@remove-dj110-warning#egg=django-select-multiple-field
+git+https://github.com/ideascube/dbus-python.git@pipified-1.1.1#egg=dbus-python
+git+https://github.com/ideascube/django-select-multiple-field@remove-dj110-warning#egg=django-select-multiple-field
 batinfo==0.4.2
 django-countries==4.0
 django-taggit==0.21.3


### PR DESCRIPTION
pip-compile doesn't support URLs as packages unless they are editable.
So we need the '-e' options in *.in files.

But, then when dh-virtualenv	install the package as editable with a
egg-link pointing to the source. As the sources change location when we
package everything, the egg-link points to nothing and we cannot import
the packages.

This is a bit silly, but the sed after the requirements.txt generation
removes the '-e' option and everything work again.
This is definitively a workaround and we should remove it once this bug is
fixed : https://github.com/spotify/dh-virtualenv/issues/200