### PR TITLE
Some fixes for the catalog/mediacenter interaction

### DIFF
--- a/ideascube/serveradmin/catalog.py
+++ b/ideascube/serveradmin/catalog.py
@@ -380,6 +380,7 @@ class ZippedMedias(SimpleZipPackage):
             raise InvalidPackageContent('Missing manifest file in {}'.format(
                 self.id))
 
+        os.makedirs(settings.MEDIA_ROOT, exist_ok=True)
         catalog_path = os.path.join(settings.MEDIA_ROOT, "catalog")
         try:
             os.symlink(install_dir, catalog_path)


### PR DESCRIPTION
See individual commits.

The second one deserves some discussion though. It seems to fix the issue, and I can then view the imported media files in the mediacenter.

However, I'm not sure of the implications this might have on everything else.

@mgautierfr Please review carefully. Especially since you wrote this code and know better its ins-and-outs.