### PR TITLE
Move from the setting files for IDEASCUBE_NAME

### DIFF
--- a/ideascube/configuration/migrations/0003_ideascube_name_to_config.py
+++ b/ideascube/configuration/migrations/0003_ideascube_name_to_config.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.db import migrations
+
+from ideascube.configuration import set_config
+
+
+def do_migrate(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
+
+    Configuration = apps.get_model('configuration', 'Configuration')
+    configs = Configuration.objects.using(db_alias)
+
+    User = apps.get_model('ideascube', 'User')
+    users = User.objects.using(db_alias)
+
+    try:
+        configs.get(namespace='server', key='site-name')
+
+    except Configuration.DoesNotExist:
+        # No value was set in the DB
+        ideascube_name = getattr(settings, 'IDEASCUBE_NAME', '')
+
+        if ideascube_name:
+            # Use the value set in the settings file
+            system_user = users.get_system_user()
+            set_config('server', 'site-name', ideascube_name, system_user)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ideascube', '0009_add_a_system_user'),
+        ('configuration', '0002_settings_to_configuration'),
+    ]
+
+    operations = [
+        migrations.RunPython(do_migrate, hints={'using': 'default'}),
+    ]

--- a/ideascube/configuration/registry.py
+++ b/ideascube/configuration/registry.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-from django.conf import settings
-
 from .exceptions import (
     NoSuchConfigurationKeyError,
     NoSuchConfigurationNamespaceError,
@@ -42,7 +40,7 @@ REGISTRY = {
                        'the web interface.',
             'pretty_type': 'A string',
             'type': str,
-            'default': getattr(settings, 'IDEASCUBE_NAME', 'Ideas Cube'),
+            'default': 'Ideas Cube',
         },
     },
 }

--- a/ideascube/tests/test_settings.py
+++ b/ideascube/tests/test_settings.py
@@ -18,8 +18,6 @@ def test_setting_file(setting_module):
 
     settings = importlib.import_module(setting_module, package="ideascube")
 
-    assert isinstance(getattr(settings, 'IDEASCUBE_NAME', ''), str)
-
     for name, _ in getattr(settings, 'USER_IMPORT_FORMATS', []):
         assert hasattr(UserImportForm, '_get_{}_mapping'.format(name))
         assert hasattr(UserImportForm, '_get_{}_reader'.format(name))


### PR DESCRIPTION
We've had the server.site-name in-database configuration for a few
releases now, and ansiblecube sets it for new boxes.

This means the time has come to start removing it from the settings
files, to eventually remove those settings files entirely.

But before removing them from the settings files, the first thing to get
old boxes to have the configuration set in their database.

This commit adds a migration which searches for an IDEASCUBE_NAME in the
settings. If it finds one, and there was no in-database server-name set,
then the configuration gets set to what was in the settings file.

Once a box will have been upgraded to a release including this
migration, then we can remove the IDEASCUBE_NAME option from their
settings file starting with the next release.

---

This is long overdue, but better late than never. 😄 

After this, we can start removing more things from the existing settings files.

And possibly even remove some settings files for some boxes, if that's the last thing they had in it.

---

I originally thought about making a management command which ansiblecube would run after an upgrade.

However, I figured a migration would make it easier to know which boxes have made the switch:

* with a migration, we just need to look at the Ideascube version on the box
* with a management command, we would need to go through the ansible logs to figure out on which box the command has been run

I'm not entirely happy though, as I think this would be better suited for a management command, since that's a one-time thing to run, and a migration would have a (minor) overhead forever in the future (e.g when running tests, creating a new box, etc...).

I'd be happier with a management command, if we can find a simple way to know whether the command has been run for a box. Any idea?