### PR TITLE
Move to the new MIDDLEWARE setting

### DIFF
--- a/ideascube/conf/base.py
+++ b/ideascube/conf/base.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = (
     'django_countries',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Django 1.10 introduced a new way to make middlewares, and to avoid
breaking compatibility they added the MIDDLEWARE setting to enable them.

Django's built-in middlewares are all compatible with both the old and
new ways, and therefore can be used with either MIDDLEWARE or
MIDDLEWARE_CLASSES.

However, one can assume that the old way will eventually get removed, so
we need to move to the new way eventually.

Fortunately, we only use Django's builtin middlewares, we don't have any
custom ones, so we only have to actually switch to the new setting. :)

https://docs.djangoproject.com/en/1.10/topics/http/middleware/