### PR TITLE
Downgrade our python-NetworkManager dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,7 +45,7 @@ pytest-flakes==1.0.1
 pytest-mock==1.5.0
 pytest==3.0.7
 python-dateutil==2.6.0    # via faker, freezegun
-python-networkmanager==2.0.0
+python-networkmanager==1.2.1
 PyYAML==3.12              # via mkdocs
 requests==2.13.0
 resumable-urlretrieve==0.1.5

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,6 @@ lxml
 Pillow
 progressist
 pymarc
-python-networkmanager
 PyYAML
 resumable-urlretrieve
 Unidecode
@@ -31,3 +30,14 @@ Unidecode
 #
 # So we forked, and took the branch someone had submitted as a pull request.
 -e git+https://github.com/ideascube/django-select-multiple-field@remove-dj110-warning#egg=django-select-multiple-field
+
+# The latest releases are giving us trouble. Version 2.0.0 is a full rewrite,
+# which seems to have broken compatibility with the old NetworkManager on
+# Debian Jessie.
+#
+# Git master has a patch to restore compatibility:
+#     https://github.com/seveas/python-networkmanager/commit/cad4dc79efd8d29e9fe1f1cd03f76e61534af808
+#
+# However, even with that applied we still seem to encounter issues. So for
+# now, we've decided to stick with the older version.
+python-networkmanager==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ olefile==0.44             # via pillow
 Pillow==4.0.0
 progressist==0.0.6
 pymarc==3.1.5
-python-networkmanager==2.0.0
+python-networkmanager==1.2.1
 PyYAML==3.12
 requests==2.13.0          # via resumable-urlretrieve
 resumable-urlretrieve==0.1.5
-six==1.10.0               # via pymarc, python-networkmanager
+six==1.10.0               # via pymarc
 Unidecode==0.4.20


### PR DESCRIPTION
The latest releases are giving us trouble. Version 2.0.0 is a full
rewrite, which seems to have broken compatibility with the old
NetworkManager on Debian Jessie.

Git master has a patch to restore compatibility:

    https://github.com/seveas/python-networkmanager/commit/cad4dc79efd8d29e9fe1f1cd03f76e61534af808

However, even with that applied we still seem to encounter issues. So
for now, we've decided to stick with the older version.